### PR TITLE
商品購入機能の作成（サーバーサイド）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,3 +101,4 @@ gem 'nokogiri'
 
 gem 'autoprefixer-rails'
 gem 'draper'
+gem 'phonelib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,7 @@ GEM
       ast (~> 2.4.0)
     payjp (0.0.7)
       rest-client (~> 2.0)
+    phonelib (0.6.38)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -416,6 +417,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4, < 0.6.0)
   nokogiri
   payjp
+  phonelib
   pry-byebug
   pry-rails
   puma (~> 3.11)

--- a/app/assets/javascripts/payjp_cards.js
+++ b/app/assets/javascripts/payjp_cards.js
@@ -1,58 +1,57 @@
 $(document).on('turbolinks:load', function() {
   // jQueryとpayjp.jsによるカード情報のトークン化
-  $(function() {
-    // Railsの通常設定では全てのページでjavascriptが読み込まれるため、
-    // カード情報に関わるページ以外で処理を行わせない
-    if(!document.URL.match('cards')) {
-      return;
-    }
-    // 自身の公開鍵をセット(テスト公開鍵)
-    Payjp.setPublicKey('pk_test_8674f42029f2ad36e1e4a30c');
-    // formを取得し追加ボタン処理でpayjpの非同期通信
-    var form = $("#card_form");
-    // 追加ボタンを押した時にカード情報をpayjpへ送りトークンを取得する
-    form.on("submit", function(e) {
-      e.preventDefault();
-      // 入力からカード情報を作成
-      var card = {
-        number: form.find("#payjp_card_number").val(),
-        cvc: form.find('#payjp_card_cvc').val(),
-        exp_month: form.find('#payjp_card_month').val(),
-        exp_year: "20" + form.find('#payjp_card_year').val()
-      };
-      //エラーメッセージ消去
-      removeErrorMessage();
-      // トークンを取得
-      Payjp.createToken(card, function(s, response) {
-        // トークン取得エラー
-        if (response.error) {
-          // エラー箇所に応じてエラーメッセージを付与
-          if (response.error.code ==  "invalid_number") {
-            buildInvalidNumberErrorMessage();
-          }
-          else if (response.error.code == "invalid_cvc") {
-            buildInvalidCVCErrorMessage();
-          }
-          else if (response.error.code == "expired_card") {
-            buildInvalidExpiredErrorMessage();
-          }
-          else if(response.error.code !== null)
-          {
-            buildInvalidCardErrorMessage();
-          }
+  // Railsの通常設定では全てのページでjavascriptが読み込まれるため、
+  // カード情報に関わるページ以外で処理を行わせない
+  if(!document.URL.match('/cards/')) {
+    return;
+  }
+  // 自身の公開鍵をセット(テスト公開鍵)
+  Payjp.setPublicKey('pk_test_8674f42029f2ad36e1e4a30c');
+  // formを取得し追加ボタン処理でpayjpの非同期通信
+  var form = $("#card_form");
+  // 追加ボタンを押した時にカード情報をpayjpへ送りトークンを取得する
+  form.on("submit", function(e) {
+    e.preventDefault();
+    // 入力からカード情報を作成
+    var card = {
+      number: form.find("#payjp_card_number").val(),
+      cvc: form.find('#payjp_card_cvc').val(),
+      exp_month: form.find('#payjp_card_month').val(),
+      exp_year: "20" + form.find('#payjp_card_year').val()
+    };
+    //エラーメッセージ消去
+    removeErrorMessage();
+    // トークンを取得
+    Payjp.createToken(card, function(s, response) {
+      // トークン取得エラー
+      if (response.error) {
+        // エラー箇所に応じてエラーメッセージを付与
+        if (response.error.code ==  "invalid_number") {
+          buildInvalidNumberErrorMessage();
         }
-        // トークン正常取得
-        else {
-          var token = response.id;
-          // payjp.jsから送られたカードトークンをformに追加してサーバーへPOST
-          form.append($('<input type="hidden" name="card_token" />').val(token));
-          form.get(0).submit();
+        else if (response.error.code == "invalid_cvc") {
+          buildInvalidCVCErrorMessage();
         }
-        //ボタン有効化
-        form.find('.card-container__form__field__button').prop('disabled', false);
-      });
+        else if (response.error.code == "expired_card") {
+          buildInvalidExpiredErrorMessage();
+        }
+        else if(response.error.code !== null)
+        {
+          buildInvalidCardErrorMessage();
+        }
+      }
+      // トークン正常取得
+      else {
+        var token = response.id;
+        // payjp.jsから送られたカードトークンをformに追加してサーバーへPOST
+        form.append($('<input type="hidden" name="card_token" />').val(token));
+        form.get(0).submit();
+      }
+      //ボタン有効化
+      form.find('.card-container__form__field__button').prop('disabled', false);
     });
   });
+
 
   // エラーメッセージ消去
   function removeErrorMessage() {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,4 +34,6 @@
  @import "./module/deals/header";
  @import "./module/deals/footer";
  @import "item";
+// バリデーション装飾なので最後に定義して他の上書きを防ぐ
+ @import "./config/validation"
 

--- a/app/assets/stylesheets/config/_validation.scss
+++ b/app/assets/stylesheets/config/_validation.scss
@@ -1,0 +1,14 @@
+input[type="text"].validation-error {
+  border: solid 1px #ea352d;
+}
+
+select.validation-error {
+  border: solid 1px #ea352d;
+}
+
+.validation-error__text {
+  margin: 8px 0 0;
+  color: $text-red;
+  line-height: 1.5;
+  font-size: 14px;
+}

--- a/app/assets/stylesheets/config/_validation.scss
+++ b/app/assets/stylesheets/config/_validation.scss
@@ -7,7 +7,7 @@ select.validation-error {
 }
 
 .validation-error__text {
-  margin: 8px 0 0;
+  margin: 8px 0;
   color: $text-red;
   line-height: 1.5;
   font-size: 14px;

--- a/app/assets/stylesheets/module/deals/_deals.scss
+++ b/app/assets/stylesheets/module/deals/_deals.scss
@@ -85,18 +85,31 @@
           }
         }
         &__button {
-          cursor: pointer;
-          color: $text-white;
-          background: $button-background-red;
-          border: none;
-          width: 100%;
-          font-size: 14px;
-          line-height: 48px;
-          font-weight: 600;
-          text-align: center;
-          &:hover {
-            background: #F28A86;
-            transition: background 0.3s;
+          &--enable {
+            border: none;
+            width: 100%;
+            font-size: 14px;
+            line-height: 48px;
+            text-align: center;
+            cursor: pointer;
+            color: $text-white;
+            background: $button-background-red;
+            font-weight: 600;
+            &:hover {
+              background: #F28A86;
+              transition: background 0.3s;
+            }
+          }
+          &--disenable {
+            border: none;
+            width: 100%;
+            font-size: 14px;
+            line-height: 48px;
+            text-align: center;
+            cursor: not-allowed;
+            color: $text-white;
+            background: #888;
+            font-weight: 600;
           }
         }
       }
@@ -121,6 +134,14 @@
           &__icon {
             margin: 0 0 0 6px;
           }
+        }
+      }
+      // 住所・カード確認
+      &__notice {
+        padding: 24px 0 40px;
+        text-align: center;
+        &--link {
+          color: #0099e8;
         }
       }
     }

--- a/app/assets/stylesheets/module/deals/_deals.scss
+++ b/app/assets/stylesheets/module/deals/_deals.scss
@@ -85,11 +85,14 @@
           }
         }
         &__button {
-          color: #fff;
-          background: #ea352d;
+          cursor: pointer;
+          color: $text-white;
+          background: $button-background-red;
+          border: none;
+          width: 100%;
           font-size: 14px;
-          font-weight: 600;
           line-height: 48px;
+          font-weight: 600;
           text-align: center;
           &:hover {
             background: #F28A86;

--- a/app/assets/stylesheets/module/deals/_deals.scss
+++ b/app/assets/stylesheets/module/deals/_deals.scss
@@ -11,6 +11,7 @@
 }
 
 .deals-content {
+  @include clearfix();
   &__section {
     margin-bottom: 1px;
     color: #333;

--- a/app/controllers/deals/deals_delivery_addresses_controller.rb
+++ b/app/controllers/deals/deals_delivery_addresses_controller.rb
@@ -2,7 +2,7 @@ class Deals::DealsDeliveryAddressesController < DeliveryAddressesController
   def new
     # 既に発送先が登録されているのにnewページを表示した時はeditページにリダイレクトする
     if current_user.delivery_address
-      redirect_to edit_item_purchase_delivery_address_path(params[:id], current_user.delivery_address)
+      redirect_to edit_item_purchase_delivery_address_path(params[:item_id], current_user.delivery_address)
     else
       super
     end

--- a/app/controllers/deals/deals_delivery_addresses_controller.rb
+++ b/app/controllers/deals/deals_delivery_addresses_controller.rb
@@ -1,2 +1,38 @@
 class Deals::DealsDeliveryAddressesController < DeliveryAddressesController
+  def new
+    # 既に発送先が登録されているのにnewページを表示した時はeditページにリダイレクトする
+    if current_user.delivery_address
+      redirect_to edit_item_purchase_delivery_address_path(params[:id], current_user.delivery_address)
+    else
+      super
+    end
+  end
+
+  def create
+    # 入力情報とユーザー情報を元に配送先を保存
+    @delivery_address = DeliveryAddress.new(address_params)
+    @delivery_address.user = current_user
+    if @delivery_address.save
+      redirect_to new_item_purchase_path
+    else
+      render :new
+    end
+  end
+
+  def update
+    # 入力情報とを元に配送先を更新
+    @delivery_address = DeliveryAddress.find(params[:id])
+    if @delivery_address.user_id == current_user.id
+      if @delivery_address.update(address_params)
+        redirect_to new_item_purchase_path
+      else
+        render :new
+      end
+    end
+  end
+
+private
+  def address_params
+    params.require(:delivery_address).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :zip_code, :prefecture_id, :city, :address, :building, :phone_number)
+  end
 end

--- a/app/controllers/deals/purchase_controller.rb
+++ b/app/controllers/deals/purchase_controller.rb
@@ -5,9 +5,13 @@ class Deals::PurchaseController < ApplicationController
 
   def new
     # 購入確認商品を取得する
-    @item = Item.find(params[:item_id])
+    @item = Item.find(params[:item_id]).decorate
     # ログインユーザーのカード情報を取得する
     @credit_card = current_user.credit_card
     @payjp_card = @credit_card&.getPayjpDefaultCard
+  end
+
+  def create
+    @deals = Deal.new(date: Date.today)
   end
 end

--- a/app/controllers/deals/purchase_controller.rb
+++ b/app/controllers/deals/purchase_controller.rb
@@ -4,34 +4,22 @@ class Deals::PurchaseController < ApplicationController
   before_action :authenticate_user!
   # APIキーを使ってPayjpクラスを初期化する
   before_action :set_api_key, only:[:create]
+  # 購入確認商品を取得する
+  before_action :get_item, only:[:new, :create]
 
   def new
-    # 購入確認商品を取得する
-    @item = Item.find(params[:item_id]).decorate
     # 商品が出品中でないのにリクエストが来た時商品詳細ページへリダイレクト
-    unless @item.sales_state_id == 1
-      redirect_to item_path(id: @item.id)
-      return
-    end
+    return redirect_to item_path(id: @item.id) unless @item.sales_state_id == 1
     # ログインユーザーのカード情報を取得する
     @credit_card = current_user.credit_card
     @payjp_card = @credit_card&.getPayjpDefaultCard
   end
 
   def create
-    # 購入確認商品を取得する
-    @item = Item.find(params[:item_id]).decorate
     # 商品が出品中でないのに購入リクエストが来た時商品詳細ページへリダイレクト
-    unless @item.sales_state_id == 1
-      redirect_to item_path(id: @item.id)
-      return
-    end
+    return redirect_to item_path(id: @item.id) unless @item.sales_state_id == 1
     # 自分の出品商品なのに購入リクエストが来た時商品詳細ページへリダイレクト
-    if @item.seller == current_user
-      redirect_to item_path(id: @item.id)
-      return
-    end
-
+    return redirect_to item_path(id: @item.id) if @item.seller == current_user
     #トランザクション開始
     ActiveRecord::Base.transaction do
       begin
@@ -71,5 +59,10 @@ class Deals::PurchaseController < ApplicationController
   def set_api_key
     require "payjp"
     Payjp.api_key = Rails.application.credentials.payjp[:api_key]
+  end
+  # 購入確認商品を取得する
+  def get_item
+    # 購入確認商品を取得する
+    @item = Item.find(params[:item_id]).decorate
   end
 end

--- a/app/controllers/deals/purchase_controller.rb
+++ b/app/controllers/deals/purchase_controller.rb
@@ -9,7 +9,7 @@ class Deals::PurchaseController < ApplicationController
 
   def new
     # 商品が出品中でないのにリクエストが来た時商品詳細ページへリダイレクト
-    return redirect_to item_path(id: @item.id) unless @item.sales_state_id == 1
+    return redirect_to item_path(@item) unless @item.sales_state_id == 1
     # ログインユーザーのカード情報を取得する
     @credit_card = current_user.credit_card
     @payjp_card = @credit_card&.getPayjpDefaultCard
@@ -17,9 +17,9 @@ class Deals::PurchaseController < ApplicationController
 
   def create
     # 商品が出品中でないのに購入リクエストが来た時商品詳細ページへリダイレクト
-    return redirect_to item_path(id: @item.id) unless @item.sales_state_id == 1
+    return redirect_to item_path(@item) unless @item.sales_state_id == 1
     # 自分の出品商品なのに購入リクエストが来た時商品詳細ページへリダイレクト
-    return redirect_to item_path(id: @item.id) if @item.seller == current_user
+    return redirect_to item_path(@item) if @item.seller == current_user
     #トランザクション開始
     ActiveRecord::Base.transaction do
       begin

--- a/app/controllers/deals/purchase_controller.rb
+++ b/app/controllers/deals/purchase_controller.rb
@@ -59,7 +59,6 @@ class Deals::PurchaseController < ApplicationController
           raise ActiveRecord::Rollback
         end
       rescue => error
-        binding.pry
         # 例外発生時は購入画面に戻りロールバックする
         render :new
         raise ActiveRecord::Rollback

--- a/app/controllers/delivery_addresses_controller.rb
+++ b/app/controllers/delivery_addresses_controller.rb
@@ -1,7 +1,12 @@
 class DeliveryAddressesController < ApplicationController
   # ログインしていない場合ログインページへ移動する
   before_action :authenticate_user!
+
   def new
     @delivery_address = DeliveryAddress.new
+  end
+
+  def edit
+    @delivery_address = current_user.delivery_address
   end
 end

--- a/app/decorators/delivery_address_decorator.rb
+++ b/app/decorators/delivery_address_decorator.rb
@@ -1,0 +1,26 @@
+class DeliveryAddressDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+  # 発送先氏名を連結して表示用に作成
+  def full_name
+    "#{last_name} #{first_name}"
+  end
+
+  # 発送先住所を連結して表示用に作成
+  def full_address
+    if(building)
+      "#{prefecture.name} #{city}#{address} #{building}"
+    else
+      "#{prefecture.name} #{city}#{address}"
+    end
+  end
+end

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -4,8 +4,7 @@ class CreditCard < ApplicationRecord
 
   #PayJPのカード情報を取得する
   def getPayJPCards()
-    require 'payjp'
-    Payjp.api_key = Rails.application.credentials.payjp[:api_key]
+    set_api_key
     customer = Payjp::Customer.retrieve(customer_id)
     payjpCards = []
     customer.cards.all().each do |card|
@@ -23,8 +22,7 @@ class CreditCard < ApplicationRecord
 
   #PayJPの顧客デフォルトカード情報を取得する
   def getPayjpDefaultCard()
-    require 'payjp'
-    Payjp.api_key = Rails.application.credentials.payjp[:api_key]
+    set_api_key
     customer = Payjp::Customer.retrieve(customer_id)
     if customer.default_card
       card = customer.cards.retrieve(customer.default_card)
@@ -39,4 +37,10 @@ class CreditCard < ApplicationRecord
     end
   end
 
+  private
+  # PAY.JP APIの秘密鍵をセット
+  def set_api_key
+    require "payjp"
+    Payjp.api_key = Rails.application.credentials.payjp[:api_key]
+  end
 end

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -2,9 +2,15 @@ class CreditCard < ApplicationRecord
   #Association
   belongs_to :user
 
+  # インスタンス化された際に実行
+  after_initialize do
+    require "payjp"
+    Payjp.api_key = Rails.application.credentials.payjp[:api_key]
+  end
+
   #PayJPのカード情報を取得する
   def getPayJPCards()
-    set_api_key
+    return [] if customer_id.nil?
     customer = Payjp::Customer.retrieve(customer_id)
     payjpCards = []
     customer.cards.all().each do |card|
@@ -22,7 +28,7 @@ class CreditCard < ApplicationRecord
 
   #PayJPの顧客デフォルトカード情報を取得する
   def getPayjpDefaultCard()
-    set_api_key
+    return nil if customer_id.nil?
     customer = Payjp::Customer.retrieve(customer_id)
     if customer.default_card
       card = customer.cards.retrieve(customer.default_card)
@@ -35,12 +41,5 @@ class CreditCard < ApplicationRecord
     else
       payjpCard = nil
     end
-  end
-
-  private
-  # PAY.JP APIの秘密鍵をセット
-  def set_api_key
-    require "payjp"
-    Payjp.api_key = Rails.application.credentials.payjp[:api_key]
   end
 end

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -4,7 +4,6 @@ class CreditCard < ApplicationRecord
 
   # インスタンス化された際に実行
   after_initialize do
-    require "payjp"
     Payjp.api_key = Rails.application.credentials.payjp[:api_key]
   end
 

--- a/app/models/deal.rb
+++ b/app/models/deal.rb
@@ -3,7 +3,7 @@ class Deal < ApplicationRecord
   validates :item, :payment, presence: true
   #Association
   has_one :item
-  has_one :payment
+  has_one :payment, dependent: :destroy
   belongs_to :buyer, class_name: 'User', foreign_key: 'buyer_id'
   belongs_to :seller, class_name: 'User', foreign_key: 'seller_id'
 end

--- a/app/models/deal.rb
+++ b/app/models/deal.rb
@@ -1,4 +1,7 @@
 class Deal < ApplicationRecord
+  #Validation
+  validates :item, :payment, presence: true
+  #Association
   has_one :item
   has_one :payment
   belongs_to :buyer, class_name: 'User', foreign_key: 'buyer_id'

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -1,2 +1,30 @@
 class DeliveryAddress < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  #Validation
+  validates :last_name, presence: true
+  validates :last_name, length: {maximum: 35}
+  validates :first_name, presence: true
+  validates :first_name, length: {maximum: 35}
+  validates :last_name_kana, presence: true
+  validates :last_name_kana, length: {maximum: 35}
+  validates :first_name_kana, presence: true
+  validates :first_name_kana, length: {maximum: 35}
+  validates :zip_code, presence: true
+  validates :zip_code, length: {maximum: 8}
+  validate :check_prefecture
+  validates :city, presence: true
+  validates :city, length: {maximum: 50}
+  validates :address, presence: true
+  validates :address, length: {maximum: 100}
+  validates :building, length: {maximum: 100}
+  validates :phone_number,length: {maximum: 35}
+  #Association
+  belongs_to :user
+  belongs_to_active_hash :prefecture
+
+  def check_prefecture
+    if prefecture_id.nil?
+      errors.add(:prefecture, "選択してください")
+    end
+  end
 end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -7,10 +7,13 @@ class DeliveryAddress < ApplicationRecord
   validates :first_name, length: {maximum: 35}
   validates :last_name_kana, presence: true
   validates :last_name_kana, length: {maximum: 35}
+  validates :last_name_kana, format: { with: /\A[\p{katakana}\p{hiragana}\p{blank}ー]+\z/ }
   validates :first_name_kana, presence: true
   validates :first_name_kana, length: {maximum: 35}
+  validates :first_name_kana, format: { with: /\A[\p{katakana}\p{hiragana}\p{blank}－]+\z/ }
   validates :zip_code, presence: true
   validates :zip_code, length: {maximum: 8}
+  validates :zip_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/}
   validate :check_prefecture
   validates :city, presence: true
   validates :city, length: {maximum: 50}
@@ -24,7 +27,7 @@ class DeliveryAddress < ApplicationRecord
 
   def check_prefecture
     if prefecture_id.nil?
-      errors.add(:prefecture, "選択してください")
+      errors.add(:prefecture_id, "選択してください")
     end
   end
 end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -7,13 +7,13 @@ class DeliveryAddress < ApplicationRecord
   validates :first_name, length: {maximum: 35}
   validates :last_name_kana, presence: true
   validates :last_name_kana, length: {maximum: 35}
-  validates :last_name_kana, format: { with: /\A[\p{katakana}\p{hiragana}\p{blank}ー]+\z/ }
+  validates :last_name_kana, format: {message: "を全角カナで入力してください", with: /\A[\p{katakana}\p{hiragana}\p{blank}ー－]+\z/ }
   validates :first_name_kana, presence: true
   validates :first_name_kana, length: {maximum: 35}
-  validates :first_name_kana, format: { with: /\A[\p{katakana}\p{hiragana}\p{blank}－]+\z/ }
+  validates :first_name_kana, format: {message: "を全角カナで入力してください", with: /\A[\p{katakana}\p{hiragana}\p{blank}ー－]+\z/ }
   validates :zip_code, presence: true
   validates :zip_code, length: {maximum: 8}
-  validates :zip_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/}
+  validates :zip_code, format: {message: "を正しく入力してください", with: /\A[0-9]{3}-[0-9]{4}\z/}
   validate :check_prefecture
   validates :city, presence: true
   validates :city, length: {maximum: 50}
@@ -27,7 +27,7 @@ class DeliveryAddress < ApplicationRecord
 
   def check_prefecture
     if prefecture_id.nil?
-      errors.add(:prefecture_id, "選択してください")
+      errors.add(:prefecture_id, "を選択してください")
     end
   end
 end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -20,7 +20,8 @@ class DeliveryAddress < ApplicationRecord
   validates :address, presence: true
   validates :address, length: {maximum: 100}
   validates :building, length: {maximum: 100}
-  validates :phone_number,length: {maximum: 35}
+  validates :phone_number, length: {maximum: 35}
+  validate :check_phone_number
   #Association
   belongs_to :user
   belongs_to_active_hash :prefecture
@@ -28,6 +29,13 @@ class DeliveryAddress < ApplicationRecord
   def check_prefecture
     if prefecture_id.nil?
       errors.add(:prefecture_id, "を選択してください")
+    end
+  end
+
+  # 空欄を許容した上で日本国内の電話番号形式かバリデーションを行う
+  def check_phone_number
+    unless phone_number.blank? || Phonelib.valid_for_country?(phone_number, :jp)
+      errors.add(:phone_number, "を正しく入力してください")
     end
   end
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,0 +1,6 @@
+class Payment < ApplicationRecord
+  #Validation
+  validates :amount, :point, presence: true
+  #Association
+  belongs_to :deal
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,9 @@ class User < ApplicationRecord
   has_many :item_comments
   has_many :item_likes
   has_one :credit_card, dependent: :destroy
+
+  # 購入可能な情報を保持しているか判定する
+  def can_purchase?
+    return delivery_address != nil && credit_card&.getPayjpDefaultCard != nil
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   has_one :profile, dependent: :destroy
   has_one :personal, dependent: :destroy
-  has_one :deliver_address, dependent: :destroy
+  has_one :delivery_address, dependent: :destroy
   has_many :items, class_name: 'Item', foreign_key: 'seller_id'
   has_many :buyer_deals, class_name: 'Deal', foreign_key: 'buyer_id'
   has_many :seller_deals, class_name: 'Deal', foreign_key: 'seller_id'

--- a/app/views/deals/deals_delivery_addresses/edit.html.haml
+++ b/app/views/deals/deals_delivery_addresses/edit.html.haml
@@ -8,7 +8,7 @@
     %section.deals-content__section
       .delivery-address-container
         = form_with model: @delivery_address, local: true, url: item_purchase_delivery_address_path(), method: :patch, class: "delivery-address-container__form" do |f|
-          = render 'delivery_addresses/form_input', {f: f}
+          = render 'delivery_addresses/form_input', {f: f, delivery_address: @delivery_address}
           .delivery-address-container__form__field
             = f.submit "変更する", class: "delivery-address-container__form__field__button"
   = render 'deals/footer'

--- a/app/views/deals/deals_delivery_addresses/edit.html.haml
+++ b/app/views/deals/deals_delivery_addresses/edit.html.haml
@@ -7,7 +7,7 @@
           発送元・お届け先住所入力
     %section.deals-content__section
       .delivery-address-container
-        = form_with model: @delivery_address, local: true, url: item_purchase_delivery_addresses_path, method: :post, id: "card_form", class: "delivery-address-container__form" do |f|
+        = form_with model: @delivery_address, local: true, url: item_purchase_delivery_address_path(), method: :patch, class: "delivery-address-container__form" do |f|
           = render 'delivery_addresses/form_input', {f: f}
           .delivery-address-container__form__field
             = f.submit "変更する", class: "delivery-address-container__form__field__button"

--- a/app/views/deals/deals_delivery_addresses/new.html.haml
+++ b/app/views/deals/deals_delivery_addresses/new.html.haml
@@ -8,7 +8,7 @@
     %section.deals-content__section
       .delivery-address-container
         = form_with model: @delivery_address, local: true, url: item_purchase_delivery_addresses_path, method: :post, id: "card_form", class: "delivery-address-container__form" do |f|
-          = render 'delivery_addresses/form_input', {f: f}
+          = render 'delivery_addresses/form_input',  {f: f, delivery_address: @delivery_address}
           .delivery-address-container__form__field
             = f.submit "変更する", class: "delivery-address-container__form__field__button"
   = render 'deals/footer'

--- a/app/views/deals/deals_payjp_cards/index.html.haml
+++ b/app/views/deals/deals_payjp_cards/index.html.haml
@@ -12,10 +12,10 @@
           = form_with url: new_item_purchase_path, method: :get, local: true do |f|
             .card-container__list__cards
               - if @payjp_cards.length > 0
-                - @payjp_cards.each do |payjp_card|
+                - @payjp_cards.each_with_index do |payjp_card, i|
                   .card-container__list__cards__card
                     = render 'payjp_cards/card', {payjp_card: payjp_card}
-                    = f.radio_button :id, value: payjp_card.id
+                    = f.radio_button :id, payjp_card.id, checked: i == 0
               %hr.card-container__list--line
               = f.submit "次に進む", class: "card-container__form__field__button"
   = render 'deals/footer'

--- a/app/views/deals/purchase/create.html.haml
+++ b/app/views/deals/purchase/create.html.haml
@@ -1,0 +1,14 @@
+.deals-wrapper
+  = render 'deals/header'
+  %main.deals-main
+    .deals-content
+      %section.deals-content__section
+        .deals-content__section__w320
+          %h2.deals-content__section__w320__headline
+            商品を購入しました
+      %section.deals-content__section
+        .deals-content__section__w320
+          %p.deals-content__section__w320__notice
+            = link_to root_path, class: "deals-content__section__w320__notice--link" do
+              トップページへ戻る
+  = render 'deals/footer'

--- a/app/views/deals/purchase/new.html.haml
+++ b/app/views/deals/purchase/new.html.haml
@@ -26,7 +26,16 @@
                   支払い金額
                 .deals-content__section__w320__order__payment__right
                   = @item.amount_text
-              = f.submit "購入する", class: "deals-content__section__w320__order__button"
+              -if current_user&.can_purchase? && @item.seller != current_user
+                = f.submit "購入する", data: {confirm: "商品を購入します。よろしいですか？"}, class: "deals-content__section__w320__order__button--enable"
+              - else
+                .validation-error__text
+                  - if @item.seller == current_user
+                    出品した商品は購入できません
+                  - else
+                    配送先と支払い方法の入力を完了してください。
+                .deals-content__section__w320__order__button--disenable
+                  購入する
         %section.deals-content__section
           .deals-content__section__w320
             .deals-content__section__w320__method

--- a/app/views/deals/purchase/new.html.haml
+++ b/app/views/deals/purchase/new.html.haml
@@ -60,7 +60,7 @@
                 支払い方法
               - if @payjp_card
                 = render 'payjp_cards/card', {payjp_card: @payjp_card}
-                = link_to item_purchase_card_index_path, class: "deals-content__section__w320__method__change" do
+                = link_to item_purchase_card_index_path, class: "deals-content__section__w320__method__change", data: {"turbolinks": false} do
                   変更する
                   = fa_icon 'angle-right lg', class: 'deals-content__section__w320__method__change__icon'
               - else

--- a/app/views/deals/purchase/new.html.haml
+++ b/app/views/deals/purchase/new.html.haml
@@ -66,7 +66,7 @@
               - else
                 .deals-content__section__w320__method__content
                   カードを登録してください
-                = link_to new_item_purchase_card_path, class: "deals-content__section__w320__method__change" do
+                = link_to new_item_purchase_card_path, class: "deals-content__section__w320__method__change", data: {"turbolinks": false} do
                   変更する
                   = fa_icon 'angle-right lg', class: 'deals-content__section__w320__method__change__icon'
   = render 'deals/footer'

--- a/app/views/deals/purchase/new.html.haml
+++ b/app/views/deals/purchase/new.html.haml
@@ -1,60 +1,63 @@
 .deals-wrapper
   = render 'deals/header'
   %main.deals-main
-    .deals-content
-      %section.deals-content__section
-        .deals-content__section__w320
-          %h2.deals-content__section__w320__headline
-            購入内容の確認
-      %section.deals-content__section
-        .deals-content__section__w320
-          .deals-content__section__w320__order
-            .deals-content__section__w320__order__item
-              = image_tag 'item-sample.jpg', class: "deals-content__section__w320__order__item__image"
-              %p.deals-content__section__w320__order__item__name
-                【オススメ‼】チャンピオン プルオーバー パーカー 星条旗 ビックロゴ 総柄
-              %p.deals-content__section__w320__order__item__cost
-                %span.deals-content__section__w320__order__item__cost--price
-                  ¥X,XXX
-                %span.deals-content__section__w320__order__item__cost--deliverymethod
-                  送料込み
-            .deals-content__section__w320__order__point
-              ポイントはありません
-            .deals-content__section__w320__order__payment
-              .deals-content__section__w320__order__payment__left
-                支払い金額
-              .deals-content__section__w320__order__payment__right
-                ¥X,XXX
-            .deals-content__section__w320__order__button
-              購入する
-      %section.deals-content__section
-        .deals-content__section__w320
-          .deals-content__section__w320__method
-            %h3.deals-content__section__w320__method__headline
-              配送先
-            .deals-content__section__w320__method__content
-              〒XXX-XXXX
-              %br
-              XX県 YYY市 ZZ町 1-2-3 ABCマンション101
-              %br
-              XX XX
-            = link_to new_item_purchase_delivery_address_path, class: "deals-content__section__w320__method__change" do
-              変更する
-              = fa_icon 'angle-right lg', class: 'deals-content__section__w320__method__change__icon'
-      %section.deals-content__section
-        .deals-content__section__w320
-          .deals-content__section__w320__method
-            %h3.deals-content__section__w320__method__headline
-              支払い方法
-            - if @payjp_card
-              = render 'payjp_cards/card', {payjp_card: @payjp_card}
-              = link_to item_purchase_card_index_path, class: "deals-content__section__w320__method__change" do
-                変更する
-                = fa_icon 'angle-right lg', class: 'deals-content__section__w320__method__change__icon'
-            - else
+    = form_with model: @item, local: true, url: item_purchase_index_path, method: :post, id: 'deal_form' do |f|
+      .deals-content
+        %section.deals-content__section
+          .deals-content__section__w320
+            %h2.deals-content__section__w320__headline
+              購入内容の確認
+        %section.deals-content__section
+          .deals-content__section__w320
+            .deals-content__section__w320__order
+              .deals-content__section__w320__order__item
+                = image_tag @item.item_images.first.image.url, class: "deals-content__section__w320__order__item__image"
+                %p.deals-content__section__w320__order__item__name
+                  = @item.name
+                %p.deals-content__section__w320__order__item__cost
+                  %span.deals-content__section__w320__order__item__cost--price
+                    = @item.amount_text
+                  %span.deals-content__section__w320__order__item__cost--deliverymethod
+                    = @item.cash_on_delevery_text
+              .deals-content__section__w320__order__point
+                ポイントはありません
+              .deals-content__section__w320__order__payment
+                .deals-content__section__w320__order__payment__left
+                  支払い金額
+                .deals-content__section__w320__order__payment__right
+                  = @item.amount_text
+              = f.submit "購入する", class: "deals-content__section__w320__order__button"
+        %section.deals-content__section
+          .deals-content__section__w320
+            .deals-content__section__w320__method
+              %h3.deals-content__section__w320__method__headline
+                配送先
               .deals-content__section__w320__method__content
-                カードを登録してください
-              = link_to new_item_purchase_card_path, class: "deals-content__section__w320__method__change" do
+                - if current_user&.delivery_address
+                  〒XXX-XXXX
+                  %br
+                  XX県 YYY市 ZZ町 1-2-3 ABCマンション101
+                  %br
+                  XX XX
+                - else
+                  配送先を登録してください
+              = link_to new_item_purchase_delivery_address_path, class: "deals-content__section__w320__method__change" do
                 変更する
                 = fa_icon 'angle-right lg', class: 'deals-content__section__w320__method__change__icon'
+        %section.deals-content__section
+          .deals-content__section__w320
+            .deals-content__section__w320__method
+              %h3.deals-content__section__w320__method__headline
+                支払い方法
+              - if @payjp_card
+                = render 'payjp_cards/card', {payjp_card: @payjp_card}
+                = link_to item_purchase_card_index_path, class: "deals-content__section__w320__method__change" do
+                  変更する
+                  = fa_icon 'angle-right lg', class: 'deals-content__section__w320__method__change__icon'
+              - else
+                .deals-content__section__w320__method__content
+                  カードを登録してください
+                = link_to new_item_purchase_card_path, class: "deals-content__section__w320__method__change" do
+                  変更する
+                  = fa_icon 'angle-right lg', class: 'deals-content__section__w320__method__change__icon'
   = render 'deals/footer'

--- a/app/views/deals/purchase/new.html.haml
+++ b/app/views/deals/purchase/new.html.haml
@@ -34,14 +34,14 @@
                 配送先
               .deals-content__section__w320__method__content
                 - if current_user&.delivery_address
-                  〒XXX-XXXX
+                  = "〒#{current_user.delivery_address.zip_code}"
                   %br
-                  XX県 YYY市 ZZ町 1-2-3 ABCマンション101
+                  = current_user.delivery_address.decorate.full_address
                   %br
-                  XX XX
+                  = current_user.delivery_address.decorate.full_name
                 - else
                   配送先を登録してください
-              = link_to new_item_purchase_delivery_address_path, class: "deals-content__section__w320__method__change" do
+              = link_to current_user.delivery_address ? edit_item_purchase_delivery_address_path(@item, current_user.delivery_address) : new_item_purchase_delivery_address_path, class: "deals-content__section__w320__method__change" do
                 変更する
                 = fa_icon 'angle-right lg', class: 'deals-content__section__w320__method__change__icon'
         %section.deals-content__section

--- a/app/views/delivery_addresses/_error_message.html.haml
+++ b/app/views/delivery_addresses/_error_message.html.haml
@@ -1,3 +1,7 @@
-- full_messages.each do |full_message|
+- if errors.added?(symbol, :blank)
   .validation-error__text
-    = full_message
+    = errors.full_messages_for(symbol).first
+- else
+  - errors.full_messages_for(symbol).each do |full_message|
+    .validation-error__text
+      = full_message

--- a/app/views/delivery_addresses/_error_message.html.haml
+++ b/app/views/delivery_addresses/_error_message.html.haml
@@ -1,0 +1,3 @@
+- full_messages.each do |full_message|
+  .validation-error__text
+    = full_message

--- a/app/views/delivery_addresses/_form_input.html.haml
+++ b/app/views/delivery_addresses/_form_input.html.haml
@@ -4,32 +4,30 @@
     %span.form--required
       必須
   = f.text_field :last_name, placeholder: "例)山田", class:"delivery-address-container__form__field__text_field"
-  - if delivery_address.errors.full_messages_for(:last_name).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:last_name)}
+  - if delivery_address.errors.include?(:last_name)
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :last_name}
   = f.text_field :first_name, placeholder: "例)彩", class:"delivery-address-container__form__field__text_field"
-  - if delivery_address.errors.full_messages_for(:first_name).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:first_name)}
-
+  - if delivery_address.errors.include?(:first_name)
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :first_name}
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label "お名前カナ"
     %span.form--required
       必須
   = f.text_field :last_name_kana, placeholder: "例)ヤマダ", class:"delivery-address-container__form__field__text_field"
-  - if delivery_address.errors.full_messages_for(:last_name_kana).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:last_name_kana)}
+  - if delivery_address.errors.include?(:last_name_kana)
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :last_name_kana}
   = f.text_field :first_name_kana, placeholder: "例)アヤ", class:"delivery-address-container__form__field__text_field"
-  - if delivery_address.errors.full_messages_for(:first_name_kana).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:first_name_kana)}
+  - if delivery_address.errors.include?(:first_name_kana)
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :first_name_kana}
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :zip_code, "郵便番号"
     %span.form--required
       必須
   = f.text_field :zip_code, placeholder: "例)123-4567", class:"delivery-address-container__form__field__text_field"
-  - if delivery_address.errors.full_messages_for(:zip_code).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:zip_code)}
-
+  - if delivery_address.errors.include?(:zip_code)
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :zip_code}
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :prefecture_id, "都道府県"
@@ -38,41 +36,37 @@
   .delivery-address-container__form__field__prefecture
     = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "---"}, {class: "delivery-address-container__form__field__prefecture__select"}
     = fa_icon 'angle-down', class: "delivery-address-container__form__field__prefecture__icon"
-  - if delivery_address.errors.full_messages_for(:prefecture_id).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:prefecture_id)}
-
+  - if delivery_address.errors.include?(:prefecture_id)
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :prefecture_id}
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :city, "市区町村"
     %span.form--required
       必須
   = f.text_field :city, placeholder: "例)横浜市緑区", class:"delivery-address-container__form__field__text_field"
-  - if delivery_address.errors.full_messages_for(:city).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:city)}
-
+  - if delivery_address.errors.include?(:city).present?
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :city}
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :address, "番地"
     %span.form--required
       必須
   = f.text_field :address, placeholder: "例)青山1-1-1", class:"delivery-address-container__form__field__text_field"
-  - if delivery_address.errors.full_messages_for(:address).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:address)}
-
+  - if delivery_address.errors.include?(:address).present?
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :city}
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :building, "建物名"
     %span.form--optional
       任意
   = f.text_field :building, placeholder: "例)柳ビル103", class:"delivery-address-container__form__field__text_field"
-  - if delivery_address.errors.full_messages_for(:building).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:building)}
-
+  - if delivery_address.errors.include?(:building).present?
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :building}
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :phone_number, "電話"
     %span.form--optional
       任意
   = f.text_field :phone_number, placeholder: "例)09012345678", class:"delivery-address-container__form__field__text_field"
-  - if delivery_address.errors.full_messages_for(:phone_number).present?
-    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:phone_number)}
+  - if delivery_address.errors.include?(:phone_number).present?
+    = render 'delivery_addresses/error_message', {errors: delivery_address.errors, symbol: :phone_number}

--- a/app/views/delivery_addresses/_form_input.html.haml
+++ b/app/views/delivery_addresses/_form_input.html.haml
@@ -4,20 +4,32 @@
     %span.form--required
       必須
   = f.text_field :last_name, placeholder: "例)山田", class:"delivery-address-container__form__field__text_field"
+  - if delivery_address.errors.full_messages_for(:last_name).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:last_name)}
   = f.text_field :first_name, placeholder: "例)彩", class:"delivery-address-container__form__field__text_field"
+  - if delivery_address.errors.full_messages_for(:first_name).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:first_name)}
+
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label "お名前カナ"
     %span.form--required
       必須
   = f.text_field :last_name_kana, placeholder: "例)ヤマダ", class:"delivery-address-container__form__field__text_field"
+  - if delivery_address.errors.full_messages_for(:last_name_kana).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:last_name_kana)}
   = f.text_field :first_name_kana, placeholder: "例)アヤ", class:"delivery-address-container__form__field__text_field"
+  - if delivery_address.errors.full_messages_for(:first_name_kana).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:first_name_kana)}
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :zip_code, "郵便番号"
     %span.form--required
       必須
   = f.text_field :zip_code, placeholder: "例)123-4567", class:"delivery-address-container__form__field__text_field"
+  - if delivery_address.errors.full_messages_for(:zip_code).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:zip_code)}
+
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :prefecture_id, "都道府県"
@@ -26,27 +38,41 @@
   .delivery-address-container__form__field__prefecture
     = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "---"}, {class: "delivery-address-container__form__field__prefecture__select"}
     = fa_icon 'angle-down', class: "delivery-address-container__form__field__prefecture__icon"
+  - if delivery_address.errors.full_messages_for(:prefecture_id).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:prefecture_id)}
+
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :city, "市区町村"
     %span.form--required
       必須
   = f.text_field :city, placeholder: "例)横浜市緑区", class:"delivery-address-container__form__field__text_field"
+  - if delivery_address.errors.full_messages_for(:city).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:city)}
+
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :address, "番地"
     %span.form--required
       必須
   = f.text_field :address, placeholder: "例)青山1-1-1", class:"delivery-address-container__form__field__text_field"
+  - if delivery_address.errors.full_messages_for(:address).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:address)}
+
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :building, "建物名"
     %span.form--optional
       任意
   = f.text_field :building, placeholder: "例)柳ビル103", class:"delivery-address-container__form__field__text_field"
+  - if delivery_address.errors.full_messages_for(:building).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:building)}
+
 .delivery-address-container__form__field
   .delivery-address-container__form__field__label
     = f.label :phone_number, "電話"
     %span.form--optional
       任意
   = f.text_field :phone_number, placeholder: "例)09012345678", class:"delivery-address-container__form__field__text_field"
+  - if delivery_address.errors.full_messages_for(:phone_number).present?
+    = render 'delivery_addresses/error_message', {full_messages: delivery_address.errors.full_messages_for(:phone_number)}

--- a/app/views/delivery_addresses/_form_input.html.haml
+++ b/app/views/delivery_addresses/_form_input.html.haml
@@ -1,0 +1,52 @@
+.delivery-address-container__form__field
+  .delivery-address-container__form__field__label
+    = f.label "お名前"
+    %span.form--required
+      必須
+  = f.text_field :last_name, placeholder: "例)山田", class:"delivery-address-container__form__field__text_field"
+  = f.text_field :first_name, placeholder: "例)彩", class:"delivery-address-container__form__field__text_field"
+.delivery-address-container__form__field
+  .delivery-address-container__form__field__label
+    = f.label "お名前カナ"
+    %span.form--required
+      必須
+  = f.text_field :last_name_kana, placeholder: "例)ヤマダ", class:"delivery-address-container__form__field__text_field"
+  = f.text_field :first_name_kana, placeholder: "例)アヤ", class:"delivery-address-container__form__field__text_field"
+.delivery-address-container__form__field
+  .delivery-address-container__form__field__label
+    = f.label :zip_code, "郵便番号"
+    %span.form--required
+      必須
+  = f.text_field :zip_code, placeholder: "例)123-4567", class:"delivery-address-container__form__field__text_field"
+.delivery-address-container__form__field
+  .delivery-address-container__form__field__label
+    = f.label :prefecture_id, "都道府県"
+    %span.form--required
+      必須
+  .delivery-address-container__form__field__prefecture
+    = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "---"}, {class: "delivery-address-container__form__field__prefecture__select"}
+    = fa_icon 'angle-down', class: "delivery-address-container__form__field__prefecture__icon"
+.delivery-address-container__form__field
+  .delivery-address-container__form__field__label
+    = f.label :city, "市区町村"
+    %span.form--required
+      必須
+  = f.text_field :city, placeholder: "例)横浜市緑区", class:"delivery-address-container__form__field__text_field"
+.delivery-address-container__form__field
+  .delivery-address-container__form__field__label
+    = f.label :address, "番地"
+    %span.form--required
+      必須
+  = f.text_field :address, placeholder: "例)青山1-1-1", class:"delivery-address-container__form__field__text_field"
+.delivery-address-container__form__field
+  .delivery-address-container__form__field__label
+    = f.label :building, "建物名"
+    %span.form--optional
+      任意
+  = f.text_field :building, placeholder: "例)柳ビル103", class:"delivery-address-container__form__field__text_field"
+.delivery-address-container__form__field
+  .delivery-address-container__form__field__label
+    = f.label :phone_number, "電話"
+    %span.form--optional
+      任意
+  = f.text_field :phone_number, placeholder: "例)09012345678", class:"delivery-address-container__form__field__text_field"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -64,7 +64,7 @@
       = @item.amount_text
       (税込)
       = @item.cash_on_delevery_text
-    = link_to "#", class: "item-purchace" do
+    = link_to new_item_purchase_path(@item), class: "item-purchace" do
       .item-purchace__button
         購入画面に進む
     .item-description

--- a/app/views/users/mypage_payjp_cards/index.html.haml
+++ b/app/views/users/mypage_payjp_cards/index.html.haml
@@ -18,7 +18,7 @@
                   = f.hidden_field :id, value: payjp_card.id
                   = f.submit '削除する', class: 'card-container__list__cards__card__destroy'
           - else
-            = link_to mypage_cards_add_path do
+            = link_to mypage_cards_add_path, data: {"turbolinks": false} do
               .card-container__list__cards__button
                 = fa_icon 'credit-card', class: 'card-container__list__cards__button__icon'
                 クレジットカードを追加する

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,6 +31,17 @@ ja:
         brand: ブランド
         deal: 取引状況
         seller: 出品者
+      delivery_address:
+        last_name: お名前（姓）
+        first_name: お名前（名）
+        last_name_kana: お名前カナ（姓）
+        first_name_kana: お名前カナ（名）
+        zip_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        address: 番地
+        building: 建物名
+        phone_number: 電話番号
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     scope module: :deals do
       resources :purchase, only: [:new, :create], path: 'transaction'
       resources :deals_payjp_cards, only: [:index, :new, :create], path: "transaction/cards", as: :purchase_card
-      resources :deals_delivery_addresses, only: [:new, :create], path: "transaction/delivery_addresses", as: :purchase_delivery_addresses
+      resources :deals_delivery_addresses, only: [:new, :create, :edit, :update], path: "transaction/delivery_addresses", as: :purchase_delivery_addresses
     end
   end
 end

--- a/db/migrate/20191022060200_create_payments.rb
+++ b/db/migrate/20191022060200_create_payments.rb
@@ -1,0 +1,10 @@
+class CreatePayments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :payments do |t|
+      t.integer :amount,            null: false
+      t.integer :point,             null: false
+      t.references :deal,           foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191022060200_create_payments.rb
+++ b/db/migrate/20191022060200_create_payments.rb
@@ -3,7 +3,7 @@ class CreatePayments < ActiveRecord::Migration[5.2]
     create_table :payments do |t|
       t.integer :amount,            null: false
       t.integer :point,             null: false
-      t.references :deal,           foreign_key: true
+      t.references :deal,           null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_11_151613) do
+ActiveRecord::Schema.define(version: 2019_10_22_060200) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -130,6 +130,15 @@ ActiveRecord::Schema.define(version: 2019_10_11_151613) do
     t.index ["seller_id"], name: "index_items_on_seller_id"
   end
 
+  create_table "payments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "amount", null: false
+    t.integer "point", null: false
+    t.bigint "deal_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deal_id"], name: "index_payments_on_deal_id"
+  end
+
   create_table "profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "introduction"
@@ -174,5 +183,6 @@ ActiveRecord::Schema.define(version: 2019_10_11_151613) do
   add_foreign_key "items", "item_states"
   add_foreign_key "items", "sales_states"
   add_foreign_key "items", "users", column: "seller_id"
+  add_foreign_key "payments", "deals"
   add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,7 +133,7 @@ ActiveRecord::Schema.define(version: 2019_10_22_060200) do
   create_table "payments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "amount", null: false
     t.integer "point", null: false
-    t.bigint "deal_id"
+    t.bigint "deal_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["deal_id"], name: "index_payments_on_deal_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,7 +63,7 @@ if Category.count == 0
     elsif row[1]
       category2 = category1.children.create(name: row[1])
     elsif row[2]
-      category2.children.create(name: row[2])
+      category3 = category2.children.create(name: row[2])
     end
   end
 end

--- a/spec/factories/deals.rb
+++ b/spec/factories/deals.rb
@@ -2,7 +2,9 @@ FactoryBot.define do
   factory :deal do
     id                {1}
     date              {Faker::Date.forward(days: 30)}
-    buyer_id          {}
-    seller_id         {}
+    buyer             {}
+    seller            {}
+    item              {}
+    payment           {}
   end
 end

--- a/spec/factories/deals.rb
+++ b/spec/factories/deals.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :deal do
+    id                {1}
+    date              {Faker::Date.forward(days: 30)}
+    buyer_id          {}
+    seller_id         {}
+  end
+end

--- a/spec/factories/delivery_address.rb
+++ b/spec/factories/delivery_address.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :delivery_address do
+    id                      {1}
+    last_name               {Faker::Name.last_name}
+    first_name              {Faker::Name.first_name}
+    last_name_kana          {'カナエ'}
+    first_name_kana         {'カナコ'}
+    zip_code                {Faker::Address.zip_code}
+    prefecture_id           {Faker::Number.between(from: 1, to: 47)}
+    city                    {Faker::Address.city}
+    address                 {Faker::Address.street_name}
+    building                {Faker::Address.secondary_address}
+    phone_number            {Faker::PhoneNumber.phone_number}
+  end
+end

--- a/spec/factories/delivery_address.rb
+++ b/spec/factories/delivery_address.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     city                    {Faker::Address.city}
     address                 {Faker::Address.street_name}
     building                {Faker::Address.secondary_address}
-    phone_number            {Faker::PhoneNumber.phone_number}
+    # Faker::PhoneNumber.phone_numberではphonelibの日本電話番号形式に準拠しない電話番号を生成するためテスト用番号はテストコードで作成する
+    phone_number            {''}
   end
 end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :payment do
+    id                {1}
+    amount            {rand(300..9999999)}
+    point             {rand(0..100000)}
+    deal_id           {}
+  end
+end

--- a/spec/models/deal_spec.rb
+++ b/spec/models/deal_spec.rb
@@ -2,58 +2,65 @@ require 'rails_helper'
 
 describe Deal do
   describe '#create' do
-    # 購入テスト用のitem(商品)を作成
-    before do
-      @item = build(:item,
-                    id: 1,
-                    category_id: 3,
-                    item_state_id: 1,
-                    deliver_expend_id: 2,
-                    deliver_method_id: 1,
-                    deliver_day_id: 2,
-                    sales_state_id: 1)
-      @item.item_images << build(:item_image)
-      # 販売者を作成
-      @item.seller = build(:user, id: 1)
-      @item.save
-      # 購入者を作成
-      ＠buyer = build(:user, id: 2)
-      ＠buyer.save
+    # 必要なデータをletで用意
+    let(:seller) { create(:user, id: 1) }
+    let(:buyer) { create(:user, id: 2) }
+    let(:item) {
+      item = build(:item,
+            id: 1,
+            category_id: 3,
+            item_state_id: 1,
+            deliver_expend_id: 2,
+            deliver_method_id: 1,
+            deliver_day_id: 2,
+            sales_state_id: 1)
+      item.item_images << build(:item_image)
+      item.seller = seller
+      item.save
+      return item
+    }
+    let(:payment) { build(:payment) }
+    let(:deal) { build(:deal, buyer:buyer, seller:seller, item:item, payment:payment) }
+
+    # バリデーションをテストする
+    subject { deal.valid? }
+
+    context 'member is not nil' do
+      it "is valid" do
+        is_expected.to eq true
+      end
     end
 
-    it "is invalid" do
-      deal = build(:deal, buyer_id:2, seller_id:1)
-      deal.payment = build(:payment)
-      deal.item = build(:item)
-      expect(deal).to be_valid
+    context 'item is nil' do
+      let(:item) { nil }
+      it "is invalid without a item" do
+        is_expected.to eq false
+        expect(deal.errors[:item]).to include("を入力してください")
+      end
     end
 
-    it "is invalid without a item" do
-      deal = build(:deal, buyer_id:2, seller_id:1)
-      deal.payment = build(:payment)
-      deal.valid?
-      expect(deal.errors[:item]).to include("を入力してください")
+    context 'payment is nil' do
+      let(:payment) { nil }
+      it "is invalid without a payment" do
+        is_expected.to eq false
+        expect(deal.errors[:payment]).to include("を入力してください")
+      end
     end
 
-    it "is invalid without a payment" do
-      deal = build(:deal, buyer_id:2, seller_id:1)
-      deal.item = build(:item)
-      deal.valid?
-      expect(deal.errors[:payment]).to include("を入力してください")
+    context 'buyer is nil' do
+      let(:buyer) { nil }
+      it "is invalid without a buyer" do
+        is_expected.to eq false
+        expect(deal.errors[:buyer]).to include("を入力してください")
+      end
     end
 
-    it "is invalid without a buyer" do
-      deal = build(:deal, buyer_id:nil, seller_id:1)
-      deal.item = build(:item)
-      deal.valid?
-      expect(deal.errors[:buyer]).to include("を入力してください")
-    end
-    
-    it "is invalid without a seller" do
-      deal = build(:deal, buyer_id:2, seller_id:nil)
-      deal.item = build(:item)
-      deal.valid?
-      expect(deal.errors[:seller]).to include("を入力してください")
+    context 'seller is nil' do
+      let(:seller) { nil }
+      it "is invalid without a seller" do
+        is_expected.to eq false
+        expect(deal.errors[:seller]).to include("を入力してください")
+      end
     end
   end
 end

--- a/spec/models/deal_spec.rb
+++ b/spec/models/deal_spec.rb
@@ -13,6 +13,7 @@ describe Deal do
                     deliver_day_id: 2,
                     sales_state_id: 1)
       @item.item_images << build(:item_image)
+      # 販売者を作成
       @item.seller = build(:user, id: 1)
       @item.save
       # 購入者を作成
@@ -20,31 +21,31 @@ describe Deal do
       ＠buyer.save
     end
     it "is invalid" do
-      deal = build(:deal, buyer_id:1, seller_id:2)
+      deal = build(:deal, buyer_id:2, seller_id:1)
       deal.payment = build(:payment)
       deal.item = build(:item)
       expect(deal).to be_valid
     end
     it "is invalid without a item" do
-      deal = build(:deal, buyer_id:1, seller_id:2)
+      deal = build(:deal, buyer_id:2, seller_id:1)
       deal.payment = build(:payment)
       deal.valid?
       expect(deal.errors[:item]).to include("を入力してください")
     end
     it "is invalid without a payment" do
-      deal = build(:deal, buyer_id:1, seller_id:2)
+      deal = build(:deal, buyer_id:2, seller_id:1)
       deal.item = build(:item)
       deal.valid?
       expect(deal.errors[:payment]).to include("を入力してください")
     end
     it "is invalid without a buyer" do
-      deal = build(:deal, buyer_id:nil, seller_id:2)
+      deal = build(:deal, buyer_id:nil, seller_id:1)
       deal.item = build(:item)
       deal.valid?
       expect(deal.errors[:buyer]).to include("を入力してください")
     end
     it "is invalid without a seller" do
-      deal = build(:deal, buyer_id:1, seller_id:nil)
+      deal = build(:deal, buyer_id:2, seller_id:nil)
       deal.item = build(:item)
       deal.valid?
       expect(deal.errors[:seller]).to include("を入力してください")

--- a/spec/models/deal_spec.rb
+++ b/spec/models/deal_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe Deal do
+  describe '#create' do
+    # 購入テスト用のitem(商品)を作成
+    before do
+      @item = build(:item,
+                    id: 1,
+                    category_id: 3,
+                    item_state_id: 1,
+                    deliver_expend_id: 2,
+                    deliver_method_id: 1,
+                    deliver_day_id: 2,
+                    sales_state_id: 1)
+      @item.item_images << build(:item_image)
+      @item.seller = build(:user, id: 1)
+      @item.save
+      # 購入者を作成
+      ＠buyer = build(:user, id: 2)
+      ＠buyer.save
+    end
+    it "is invalid" do
+      deal = build(:deal, buyer_id:1, seller_id:2)
+      deal.payment = build(:payment)
+      deal.item = build(:item)
+      expect(deal).to be_valid
+    end
+    it "is invalid without a item" do
+      deal = build(:deal, buyer_id:1, seller_id:2)
+      deal.payment = build(:payment)
+      deal.valid?
+      expect(deal.errors[:item]).to include("を入力してください")
+    end
+    it "is invalid without a payment" do
+      deal = build(:deal, buyer_id:1, seller_id:2)
+      deal.item = build(:item)
+      deal.valid?
+      expect(deal.errors[:payment]).to include("を入力してください")
+    end
+    it "is invalid without a buyer" do
+      deal = build(:deal, buyer_id:nil, seller_id:2)
+      deal.item = build(:item)
+      deal.valid?
+      expect(deal.errors[:buyer]).to include("を入力してください")
+    end
+    it "is invalid without a seller" do
+      deal = build(:deal, buyer_id:1, seller_id:nil)
+      deal.item = build(:item)
+      deal.valid?
+      expect(deal.errors[:seller]).to include("を入力してください")
+    end
+  end
+end

--- a/spec/models/deal_spec.rb
+++ b/spec/models/deal_spec.rb
@@ -20,30 +20,35 @@ describe Deal do
       ＠buyer = build(:user, id: 2)
       ＠buyer.save
     end
+
     it "is invalid" do
       deal = build(:deal, buyer_id:2, seller_id:1)
       deal.payment = build(:payment)
       deal.item = build(:item)
       expect(deal).to be_valid
     end
+
     it "is invalid without a item" do
       deal = build(:deal, buyer_id:2, seller_id:1)
       deal.payment = build(:payment)
       deal.valid?
       expect(deal.errors[:item]).to include("を入力してください")
     end
+
     it "is invalid without a payment" do
       deal = build(:deal, buyer_id:2, seller_id:1)
       deal.item = build(:item)
       deal.valid?
       expect(deal.errors[:payment]).to include("を入力してください")
     end
+
     it "is invalid without a buyer" do
       deal = build(:deal, buyer_id:nil, seller_id:1)
       deal.item = build(:item)
       deal.valid?
       expect(deal.errors[:buyer]).to include("を入力してください")
     end
+    
     it "is invalid without a seller" do
       deal = build(:deal, buyer_id:2, seller_id:nil)
       deal.item = build(:item)

--- a/spec/models/delivery_address_spec.rb
+++ b/spec/models/delivery_address_spec.rb
@@ -10,7 +10,7 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:last_name]).to include("を入力してください")
       end
-      it "is valid a last_name that has less than　or equal to 35 characters" do
+      it "is valid a last_name that has less than or equal to 35 characters" do
         delivery_address = build(:delivery_address, last_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえお")
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
@@ -30,7 +30,7 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:first_name]).to include("を入力してください")
       end
-      it "is valid a first_name that has less than　or equal to 35 characters" do
+      it "is valid a first_name that has less than or equal to 35 characters" do
         delivery_address = build(:delivery_address, first_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえお")
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
@@ -50,7 +50,7 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:last_name_kana]).to include("を入力してください")
       end
-      it "is valid a last_name_kana that has less than　or equal to 35 characters" do
+      it "is valid a last_name_kana that has less than or equal to 35 characters" do
         delivery_address = build(:delivery_address, last_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオ")
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
@@ -93,7 +93,7 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:first_name_kana]).to include("を入力してください")
       end
-      it "is valid a first_name_kana that has less than　or equal to 35 characters" do
+      it "is valid a first_name_kana that has less than or equal to 35 characters" do
         delivery_address = build(:delivery_address, first_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオ")
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
@@ -176,7 +176,7 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:city]).to include("を入力してください")
       end
-      it "is valid a city that has less than　or equal to 50 characters" do
+      it "is valid a city that has less than or equal to 50 characters" do
         delivery_address = build(:delivery_address, city:Faker::String.random(length: 50))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
@@ -196,7 +196,7 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:address]).to include("を入力してください")
       end
-      it "is valid a address that has less than　or equal to 100 characters" do
+      it "is valid a address that has less than or equal to 100 characters" do
         delivery_address = build(:delivery_address, address:Faker::String.random(length: 100))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
@@ -210,7 +210,7 @@ describe DeliveryAddress do
     end
     # 建物名
     describe "building" do
-      it "is valid a building that has less than　or equal to 100 characters" do
+      it "is valid a building that has less than or equal to 100 characters" do
         delivery_address = build(:delivery_address, building:Faker::String.random(length: 100))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
@@ -224,16 +224,33 @@ describe DeliveryAddress do
     end
     # 電話番号
     describe "phone_number" do
-      it "is valid a building that has less than　or equal to 35 characters" do
+      it "is valid a phone_number that has less than or equal to 35 characters" do
         delivery_address = build(:delivery_address, phone_number:Faker::Number.leading_zero_number(digits: 35))
         delivery_address.user = build(:user)
-        expect(delivery_address).to be_valid
+        delivery_address.valid?
+        expect(delivery_address.errors[:phone_number]).not_to include("は35文字以内で入力してください")
       end
       it "is invalid a phone_number that has more than 35 characters" do
         delivery_address = build(:delivery_address, phone_number:Faker::Number.leading_zero_number(digits: 36))
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:phone_number]).to include("は35文字以内で入力してください")
+      end
+      it "is valid a phone_number" do
+        delivery_address = build(:delivery_address, phone_number:"0527412222")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is valid a phone_number with hyphen" do
+        delivery_address = build(:delivery_address, phone_number:"052-741-2222")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a phone_number random 10 characters" do
+        delivery_address = build(:delivery_address, phone_number:Faker::String.random(length: 10))
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:phone_number]).to include("を正しく入力してください")
       end
     end
   end

--- a/spec/models/delivery_address_spec.rb
+++ b/spec/models/delivery_address_spec.rb
@@ -11,12 +11,12 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:last_name]).to include("を入力してください")
       end
       it "is valid a last_name that has less than or equal to 35 characters" do
-        delivery_address = build(:delivery_address, last_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえお")
+        delivery_address = build(:delivery_address, last_name:Faker::String.random(length: 35))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
       it "is invalid a last_name that has more than 35 characters" do
-        delivery_address = build(:delivery_address, last_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおか")
+        delivery_address = build(:delivery_address, last_name:Faker::String.random(length: 36))
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:last_name]).to include("は35文字以内で入力してください")
@@ -31,12 +31,12 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:first_name]).to include("を入力してください")
       end
       it "is valid a first_name that has less than or equal to 35 characters" do
-        delivery_address = build(:delivery_address, first_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえお")
+        delivery_address = build(:delivery_address, first_name:Faker::String.random(length: 35))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
       it "is invalid a first_name that has more than 35 characters" do
-        delivery_address = build(:delivery_address, first_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおか")
+        delivery_address = build(:delivery_address, first_name:Faker::String.random(length: 36))
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:first_name]).to include("は35文字以内で入力してください")
@@ -51,12 +51,12 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:last_name_kana]).to include("を入力してください")
       end
       it "is valid a last_name_kana that has less than or equal to 35 characters" do
-        delivery_address = build(:delivery_address, last_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオ")
+        delivery_address = build(:delivery_address, last_name_kana:('ァ'..'ヴ').to_a.sample(35).join)
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
       it "is invalid a last_name_kana that has more than 35 characters" do
-        delivery_address = build(:delivery_address, last_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオカ")
+        delivery_address = build(:delivery_address, last_name_kana:('ァ'..'ヴ').to_a.sample(36).join)
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:last_name_kana]).to include("は35文字以内で入力してください")
@@ -94,12 +94,12 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:first_name_kana]).to include("を入力してください")
       end
       it "is valid a first_name_kana that has less than or equal to 35 characters" do
-        delivery_address = build(:delivery_address, first_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオ")
+        delivery_address = build(:delivery_address, first_name_kana:('ァ'..'ヴ').to_a.sample(35).join)
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
       it "is invalid a first_name_kana that has more than 35 characters" do
-        delivery_address = build(:delivery_address, first_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオカ")
+        delivery_address = build(:delivery_address, first_name_kana:('ァ'..'ヴ').to_a.sample(36).join)
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:first_name_kana]).to include("は35文字以内で入力してください")
@@ -157,7 +157,7 @@ describe DeliveryAddress do
     # 都道府県
     describe "prefecture" do
       it "is valid a prefecture is selected" do
-        delivery_address = build(:delivery_address, prefecture_id:"20")
+        delivery_address = build(:delivery_address, prefecture_id:Faker::Number.between(from: 1, to: 47))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end

--- a/spec/models/delivery_address_spec.rb
+++ b/spec/models/delivery_address_spec.rb
@@ -10,11 +10,13 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:last_name]).to include("を入力してください")
       end
+
       it "is valid a last_name that has less than or equal to 35 characters" do
         delivery_address = build(:delivery_address, last_name:Faker::String.random(length: 35))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a last_name that has more than 35 characters" do
         delivery_address = build(:delivery_address, last_name:Faker::String.random(length: 36))
         delivery_address.user = build(:user)
@@ -22,6 +24,7 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:last_name]).to include("は35文字以内で入力してください")
       end
     end
+
     # お名前（名）
     describe "first_name" do
       it "is invalid without a first_name" do
@@ -30,11 +33,13 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:first_name]).to include("を入力してください")
       end
+
       it "is valid a first_name that has less than or equal to 35 characters" do
         delivery_address = build(:delivery_address, first_name:Faker::String.random(length: 35))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a first_name that has more than 35 characters" do
         delivery_address = build(:delivery_address, first_name:Faker::String.random(length: 36))
         delivery_address.user = build(:user)
@@ -42,6 +47,7 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:first_name]).to include("は35文字以内で入力してください")
       end
     end
+
     # お名前カナ（姓）
     describe "last_name_kana" do
       it "is invalid without a last_name_kana" do
@@ -50,34 +56,40 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:last_name_kana]).to include("を入力してください")
       end
+
       it "is valid a last_name_kana that has less than or equal to 35 characters" do
         delivery_address = build(:delivery_address, last_name_kana:('ァ'..'ヴ').to_a.sample(35).join)
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a last_name_kana that has more than 35 characters" do
         delivery_address = build(:delivery_address, last_name_kana:('ァ'..'ヴ').to_a.sample(36).join)
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:last_name_kana]).to include("は35文字以内で入力してください")
       end
+
       it "is valid a last_name_kana that has katakana characters" do
         delivery_address = build(:delivery_address, last_name_kana:"カタカナ")
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a last_name_kana that has alphabet characters" do
         delivery_address = build(:delivery_address, last_name_kana:"ABCDE")
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:last_name_kana]).to include("を全角カナで入力してください")
       end
+
       it "is invalid a last_name_kana that has kanji characters" do
         delivery_address = build(:delivery_address, last_name_kana:"亜胃雨絵尾")
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:last_name_kana]).to include("を全角カナで入力してください")
       end
+
       it "is invalid a last_name_kana that has other characters" do
         delivery_address = build(:delivery_address, last_name_kana:"+-*/")
         delivery_address.user = build(:user)
@@ -85,6 +97,7 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:last_name_kana]).to include("を全角カナで入力してください")
       end
     end
+
     # お名前カナ（名）
     describe "first_name_kana" do
       it "is invalid without a first_name_kana" do
@@ -93,34 +106,40 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:first_name_kana]).to include("を入力してください")
       end
+
       it "is valid a first_name_kana that has less than or equal to 35 characters" do
         delivery_address = build(:delivery_address, first_name_kana:('ァ'..'ヴ').to_a.sample(35).join)
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a first_name_kana that has more than 35 characters" do
         delivery_address = build(:delivery_address, first_name_kana:('ァ'..'ヴ').to_a.sample(36).join)
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:first_name_kana]).to include("は35文字以内で入力してください")
       end
+
       it "is valid a first_name_kana that has katakana characters" do
         delivery_address = build(:delivery_address, first_name_kana:"カタカナ")
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a first_name_kana that has alphabet characters" do
         delivery_address = build(:delivery_address, first_name_kana:"ABCDE")
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:first_name_kana]).to include("を全角カナで入力してください")
       end
+
       it "is invalid a first_name_kana that has kanji characters" do
         delivery_address = build(:delivery_address, first_name_kana:"亜胃雨絵尾")
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:first_name_kana]).to include("を全角カナで入力してください")
       end
+
       it "is invalid a first_name_kana that has other characters" do
         delivery_address = build(:delivery_address, first_name_kana:"+-*/")
         delivery_address.user = build(:user)
@@ -128,6 +147,7 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:first_name_kana]).to include("を全角カナで入力してください")
       end
     end
+
     # 郵便番号
     describe "zip_code" do
       it "is invalid without a zip_code" do
@@ -136,17 +156,20 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:zip_code]).to include("を入力してください")
       end
+
       it "is invalid a zip_code that has more than 8 characters" do
         delivery_address = build(:delivery_address, zip_code:"1234-5678")
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:zip_code]).to include("は8文字以内で入力してください")
       end
+
       it "is valid a zip_code match to the regular expression" do
         delivery_address = build(:delivery_address, zip_code:"123-5678")
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a zip_code match to the regular expression" do
         delivery_address = build(:delivery_address, zip_code:"13-32678")
         delivery_address.user = build(:user)
@@ -154,6 +177,7 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:zip_code]).to include("を正しく入力してください")
       end
     end
+
     # 都道府県
     describe "prefecture" do
       it "is valid a prefecture is selected" do
@@ -161,6 +185,7 @@ describe DeliveryAddress do
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a prefecture is not selected" do
         delivery_address = build(:delivery_address, prefecture_id:nil)
         delivery_address.user = build(:user)
@@ -168,6 +193,7 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:prefecture_id]).to include("を選択してください")
       end
     end
+
     # 市区町村
     describe "city" do
       it "is invalid without a city" do
@@ -176,11 +202,13 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:city]).to include("を入力してください")
       end
+
       it "is valid a city that has less than or equal to 50 characters" do
         delivery_address = build(:delivery_address, city:Faker::String.random(length: 50))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a city that has more than 50 characters" do
         delivery_address = build(:delivery_address, city:Faker::String.random(length: 51))
         delivery_address.user = build(:user)
@@ -188,6 +216,7 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:city]).to include("は50文字以内で入力してください")
       end
     end
+
     # 住所
     describe "address" do
       it "is invalid without a address" do
@@ -196,11 +225,13 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:address]).to include("を入力してください")
       end
+
       it "is valid a address that has less than or equal to 100 characters" do
         delivery_address = build(:delivery_address, address:Faker::String.random(length: 100))
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a address that has more than 100 characters" do
         delivery_address = build(:delivery_address, address:Faker::String.random(length: 101))
         delivery_address.user = build(:user)
@@ -208,6 +239,7 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:address]).to include("は100文字以内で入力してください")
       end
     end
+
     # 建物名
     describe "building" do
       it "is valid a building that has less than or equal to 100 characters" do
@@ -215,6 +247,7 @@ describe DeliveryAddress do
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is invalid a building that has more than 100 characters" do
         delivery_address = build(:delivery_address, building:Faker::String.random(length: 101))
         delivery_address.user = build(:user)
@@ -222,6 +255,7 @@ describe DeliveryAddress do
         expect(delivery_address.errors[:building]).to include("は100文字以内で入力してください")
       end
     end
+
     # 電話番号
     describe "phone_number" do
       it "is valid a phone_number that has less than or equal to 35 characters" do
@@ -230,22 +264,26 @@ describe DeliveryAddress do
         delivery_address.valid?
         expect(delivery_address.errors[:phone_number]).not_to include("は35文字以内で入力してください")
       end
+
       it "is invalid a phone_number that has more than 35 characters" do
         delivery_address = build(:delivery_address, phone_number:Faker::Number.leading_zero_number(digits: 36))
         delivery_address.user = build(:user)
         delivery_address.valid?
         expect(delivery_address.errors[:phone_number]).to include("は35文字以内で入力してください")
       end
+
       it "is valid a phone_number" do
         delivery_address = build(:delivery_address, phone_number:"0527412222")
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+
       it "is valid a phone_number with hyphen" do
         delivery_address = build(:delivery_address, phone_number:"052-741-2222")
         delivery_address.user = build(:user)
         expect(delivery_address).to be_valid
       end
+      
       it "is invalid a phone_number random 10 characters" do
         delivery_address = build(:delivery_address, phone_number:Faker::String.random(length: 10))
         delivery_address.user = build(:user)

--- a/spec/models/delivery_address_spec.rb
+++ b/spec/models/delivery_address_spec.rb
@@ -1,0 +1,240 @@
+require 'rails_helper'
+
+describe DeliveryAddress do
+  describe "#create" do
+    # お名前（姓）
+    describe "last_name" do
+      it "is invalid without a last_name" do
+        delivery_address = build(:delivery_address, last_name:"")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:last_name]).to include("を入力してください")
+      end
+      it "is valid a last_name that has less than　or equal to 35 characters" do
+        delivery_address = build(:delivery_address, last_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえお")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a last_name that has more than 35 characters" do
+        delivery_address = build(:delivery_address, last_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおか")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:last_name]).to include("は35文字以内で入力してください")
+      end
+    end
+    # お名前（名）
+    describe "first_name" do
+      it "is invalid without a first_name" do
+        delivery_address = build(:delivery_address, first_name:"")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:first_name]).to include("を入力してください")
+      end
+      it "is valid a first_name that has less than　or equal to 35 characters" do
+        delivery_address = build(:delivery_address, first_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえお")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a first_name that has more than 35 characters" do
+        delivery_address = build(:delivery_address, first_name:"あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおか")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:first_name]).to include("は35文字以内で入力してください")
+      end
+    end
+    # お名前カナ（姓）
+    describe "last_name_kana" do
+      it "is invalid without a last_name_kana" do
+        delivery_address = build(:delivery_address, last_name_kana:"")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:last_name_kana]).to include("を入力してください")
+      end
+      it "is valid a last_name_kana that has less than　or equal to 35 characters" do
+        delivery_address = build(:delivery_address, last_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオ")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a last_name_kana that has more than 35 characters" do
+        delivery_address = build(:delivery_address, last_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオカ")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:last_name_kana]).to include("は35文字以内で入力してください")
+      end
+      it "is valid a last_name_kana that has katakana characters" do
+        delivery_address = build(:delivery_address, last_name_kana:"カタカナ")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a last_name_kana that has alphabet characters" do
+        delivery_address = build(:delivery_address, last_name_kana:"ABCDE")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:last_name_kana]).to include("を全角カナで入力してください")
+      end
+      it "is invalid a last_name_kana that has kanji characters" do
+        delivery_address = build(:delivery_address, last_name_kana:"亜胃雨絵尾")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:last_name_kana]).to include("を全角カナで入力してください")
+      end
+      it "is invalid a last_name_kana that has other characters" do
+        delivery_address = build(:delivery_address, last_name_kana:"+-*/")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:last_name_kana]).to include("を全角カナで入力してください")
+      end
+    end
+    # お名前カナ（名）
+    describe "first_name_kana" do
+      it "is invalid without a first_name_kana" do
+        delivery_address = build(:delivery_address, first_name_kana:"")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:first_name_kana]).to include("を入力してください")
+      end
+      it "is valid a first_name_kana that has less than　or equal to 35 characters" do
+        delivery_address = build(:delivery_address, first_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオ")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a first_name_kana that has more than 35 characters" do
+        delivery_address = build(:delivery_address, first_name_kana:"アイウエオカキクケコアイウエオカキクケコアイウエオカキクケコアイウエオカ")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:first_name_kana]).to include("は35文字以内で入力してください")
+      end
+      it "is valid a first_name_kana that has katakana characters" do
+        delivery_address = build(:delivery_address, first_name_kana:"カタカナ")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a first_name_kana that has alphabet characters" do
+        delivery_address = build(:delivery_address, first_name_kana:"ABCDE")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:first_name_kana]).to include("を全角カナで入力してください")
+      end
+      it "is invalid a first_name_kana that has kanji characters" do
+        delivery_address = build(:delivery_address, first_name_kana:"亜胃雨絵尾")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:first_name_kana]).to include("を全角カナで入力してください")
+      end
+      it "is invalid a first_name_kana that has other characters" do
+        delivery_address = build(:delivery_address, first_name_kana:"+-*/")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:first_name_kana]).to include("を全角カナで入力してください")
+      end
+    end
+    # 郵便番号
+    describe "zip_code" do
+      it "is invalid without a zip_code" do
+        delivery_address = build(:delivery_address, zip_code:"")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:zip_code]).to include("を入力してください")
+      end
+      it "is invalid a zip_code that has more than 8 characters" do
+        delivery_address = build(:delivery_address, zip_code:"1234-5678")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:zip_code]).to include("は8文字以内で入力してください")
+      end
+      it "is valid a zip_code match to the regular expression" do
+        delivery_address = build(:delivery_address, zip_code:"123-5678")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a zip_code match to the regular expression" do
+        delivery_address = build(:delivery_address, zip_code:"13-32678")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:zip_code]).to include("を正しく入力してください")
+      end
+    end
+    # 都道府県
+    describe "prefecture" do
+      it "is valid a prefecture is selected" do
+        delivery_address = build(:delivery_address, prefecture_id:"20")
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a prefecture is not selected" do
+        delivery_address = build(:delivery_address, prefecture_id:nil)
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:prefecture_id]).to include("を選択してください")
+      end
+    end
+    # 市区町村
+    describe "city" do
+      it "is invalid without a city" do
+        delivery_address = build(:delivery_address, city:"")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:city]).to include("を入力してください")
+      end
+      it "is valid a city that has less than　or equal to 50 characters" do
+        delivery_address = build(:delivery_address, city:Faker::String.random(length: 50))
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a city that has more than 50 characters" do
+        delivery_address = build(:delivery_address, city:Faker::String.random(length: 51))
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:city]).to include("は50文字以内で入力してください")
+      end
+    end
+    # 住所
+    describe "address" do
+      it "is invalid without a address" do
+        delivery_address = build(:delivery_address, address:"")
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:address]).to include("を入力してください")
+      end
+      it "is valid a address that has less than　or equal to 100 characters" do
+        delivery_address = build(:delivery_address, address:Faker::String.random(length: 100))
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a address that has more than 100 characters" do
+        delivery_address = build(:delivery_address, address:Faker::String.random(length: 101))
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:address]).to include("は100文字以内で入力してください")
+      end
+    end
+    # 建物名
+    describe "building" do
+      it "is valid a building that has less than　or equal to 100 characters" do
+        delivery_address = build(:delivery_address, building:Faker::String.random(length: 100))
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a building that has more than 100 characters" do
+        delivery_address = build(:delivery_address, building:Faker::String.random(length: 101))
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:building]).to include("は100文字以内で入力してください")
+      end
+    end
+    # 電話番号
+    describe "phone_number" do
+      it "is valid a building that has less than　or equal to 35 characters" do
+        delivery_address = build(:delivery_address, phone_number:Faker::Number.leading_zero_number(digits: 35))
+        delivery_address.user = build(:user)
+        expect(delivery_address).to be_valid
+      end
+      it "is invalid a phone_number that has more than 35 characters" do
+        delivery_address = build(:delivery_address, phone_number:Faker::Number.leading_zero_number(digits: 36))
+        delivery_address.user = build(:user)
+        delivery_address.valid?
+        expect(delivery_address.errors[:phone_number]).to include("は35文字以内で入力してください")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What
他のユーザーが出品した商品を購入する機能を追加する

# Why
商品購入のやりとりを行うため

# 補足
## テーブル追加
- delivery_addressesテーブル
配送先住所を記録するテーブル
- paymentsテーブル
支払い金額と使用ポイントを記録するテーブル
## テスト
単体テストは以下のコマンドを実行してください
bundle exec rake db:seed RAILS_ENV=test
bundle exec rspec spec/models/delivery_address_spec.rb
bundle exec rspec spec/models/deal_spec.rb