### PR TITLE
商品詳細ページの作成（出品者用、画像の切り替え）

### DIFF
--- a/app/assets/javascripts/sell_item_image_changer.js
+++ b/app/assets/javascripts/sell_item_image_changer.js
@@ -1,0 +1,30 @@
+$(document).on('turbolinks:load', function() {
+  // 商品詳細ページの以外のパスでない時処理を行わない
+  var re = new RegExp('/items/[0-9]+$');
+  if(!re.test(location.pathname)) {
+    return;
+  }
+  // 商品のトップ表示画像を取得
+  var top_image = document.querySelector(".item-detail__infomation__images__top__image");
+  // リスト中のハイライト画像を取得
+  var selected_image = document.querySelector(".item-detail__infomation__images__flex__box__image--selected");
+  // 画像一覧ファイルを取得
+  var images = document.querySelectorAll('.item-detail__infomation__images__flex__box')
+  // イベント登録
+  for(i = 0; i < images.length; i++) {
+    images[i].addEventListener('mouseenter', (e) => {
+      // マウスが通過した画像をトップ表示画像に切り替える
+      var enter_image = e.target.querySelector("img");
+      if (enter_image !== selected_image) {
+        top_image.src = enter_image.src
+        // ハイライトCSSの付け替え
+        selected_image.classList.remove('item-detail__infomation__images__flex__box__image--selected');
+        enter_image.classList.add('item-detail__infomation__images__flex__box__image--selected');
+        selected_image = enter_image;
+        // 画像をフェードアウト後フェードインを行う
+        $('.item-detail__infomation__images__top__image').stop(false, false).fadeOut(250);
+        $('.item-detail__infomation__images__top__image').stop(false, true).fadeIn(750);
+      }
+    });
+  }
+});

--- a/app/assets/stylesheets/module/items/_detail.scss
+++ b/app/assets/stylesheets/module/items/_detail.scss
@@ -190,6 +190,45 @@
   }
 }
 
+.item-seller-edit {
+  padding: 24px 12px;
+  margin-bottom: 8px;
+  color: $text-deepgray;
+  background: $background-white;
+  &__or {
+    text-align: center;
+    margin: 0 0 16px;
+  }
+  &__button {
+    &--enable {
+      border: none;
+      margin: 0 0 16px;
+      width: 100%;
+      font-size: 14px;
+      line-height: 48px;
+      text-align: center;
+      cursor: pointer;
+      color: $text-white;
+      background: $button-background-red;
+      font-weight: 500;
+      &:hover {
+        background: #F28A86;
+        transition: background 0.3s;
+      }
+    }
+    &--disenable {
+      border: none;
+      margin: 0 0 16px;
+      width: 100%;
+      font-size: 14px;
+      line-height: 48px;
+      text-align: center;
+      color: $text-white;
+      background: #888;
+    }
+  }
+}
+
 .item-chat {
   padding: 24px;
   margin-bottom: 8px;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,4 +1,7 @@
 = render 'joint/header'
+-# 出品者の場合パンくずリストを表示
+- if @item.seller == current_user
+  = render 'users/user-breadcrumb'
 .item-wrapper
   %main.item-main
     .item-detail
@@ -84,15 +87,16 @@
           (税込)
         %span.item-detail__amount--tax
         = @item.cash_on_delevery_text
-      -# 購入ボタン
-      .item-detail__purchace
-        - if @item.sales_state_id == 1
-          = link_to new_item_purchase_path(@item), class: "item-detail__purchace__button" do
-            .item-detail__purchace__button--enable
-              購入画面に進む
-        - else
-          .item-detail__purchace__button--disenable
-            売り切れです
+      -# 出品者以外のユーザーは購入ボタンを表示
+      - if @item.seller != current_user
+        .item-detail__purchace
+          - if @item.sales_state_id == 1
+            = link_to new_item_purchase_path(@item), class: "item-detail__purchace__button" do
+              .item-detail__purchace__button--enable
+                購入画面に進む
+          - else
+            .item-detail__purchace__button--disenable
+              売り切れです
       -# 説明文
       .item-detail__description
         = simple_format(@item.description, class:"item-detail__description__text")
@@ -107,6 +111,25 @@
         = link_to "#", class:"item-detail__footer__link" do
           = fa_icon 'lock', class: "item-detail__footer__link__icon"
           あんしん・あんぜんへの取り組み
+    -# 出品者のみ商品状態変更ボタンを表示
+    - if @item.seller == current_user && @item.sales_state_id != 3
+      .item-seller-edit
+        = link_to edit_item_path(@item) do
+          .item-seller-edit__button--enable
+            商品の編集
+        .item-seller-edit__or
+          or
+        - if @item.sales_state_id == 1
+          = link_to "#" do
+            .item-seller-edit__button--disenable
+              出品を一旦停止する
+        - elsif @item.sales_state_id == 2
+          = link_to "#" do
+            .item-seller-edit__button--enable
+              出品を再開する
+        = link_to item_path(@item), method: :destroy, data: {confirm: "削除すると二度と復活できません。\n削除する代わりに停止することもできます。\n\n本当に削除しますか？ "} do
+          .item-seller-edit__button--disenable
+            この商品を削除する
     -# コメント機能は必須でないため暫定的に見た目だけ用意
     .item-chat
       .item-chat__notice
@@ -114,7 +137,10 @@
       = form_with url: "" do |f|
         = f.text_area :message, class: "item-chat__textarea"
       .item-chat__button--disenable
-        コメントする
+        - if @item.sales_state_id == 1
+          コメントする
+        - else
+          売り切れのためコメントできません
     -# SNSシェアボタン
     .item-share
       %ul.item-share__icon-list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
-  resources :items, only:[:index, :show, :new, :create, :edit, :update] do
+  resources :items do
     # 商品購入ページ
     scope module: :deals do
       resources :purchase, only: [:new, :create], path: 'transaction'


### PR DESCRIPTION
What
商品の詳細情報ページに出品者専用の編集ボタン、リンクを表示する。
出品画像が複数ある時に他の商品画像をマウスオーバーした際に画像を切り替える機能を追加する。

Why
出品者が出品した商品の編集や、取り消しを行う操作を行うために必要だから。
出品した商品の画像を手軽に切り替えて確認するため。