### PR TITLE
トップページ・ヘッダのマークアップ修正

### DIFF
--- a/app/assets/stylesheets/module/root/header/_header.scss
+++ b/app/assets/stylesheets/module/root/header/_header.scss
@@ -119,6 +119,27 @@
             color:white;
           }
         }
+        &__mypage {
+          color: $text-deepgray;
+          height: 36px;
+          line-height: 36px;
+          box-sizing: border-box;
+          text-decoration: none;
+          &__avator {
+            border-radius: 50%;
+            vertical-align: middle;
+            margin: 0 8px 0 0;
+          }
+          &__text
+          {
+            font-size: 14px;
+            display: inline-block;
+            vertical-align: middle;
+          }
+          &:hover{
+            color: $link-hover;
+          }
+        }
       }
     }
   }
@@ -172,6 +193,15 @@
           &:hover{
             background-color: $link-hover;
             color:white;
+          }
+        }
+        &__mypage {
+          height: 36px;
+          line-height: 36px;
+          box-sizing: border-box;
+          &__avator {
+            vertical-align: middle;
+            border-radius: 50%;
           }
         }
       }

--- a/app/views/joint/_exhibit__button.html.haml
+++ b/app/views/joint/_exhibit__button.html.haml
@@ -1,5 +1,5 @@
 .root-exhibit__button
-  =link_to "items/new",class: "root-exhibit__button" do
+  =link_to new_item_path ,class: "root-exhibit__button" do
     .root-exhibit__button--text
       出品
       = fa_icon "camera 3x", class: "root-exhibit__button__icon"

--- a/app/views/joint/_footer.html.haml
+++ b/app/views/joint/_footer.html.haml
@@ -5,19 +5,19 @@
         メルカリについて
       %ul.root-footer__menu__nav__list--outline
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             会社概要（運営会社）
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             採用情報
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             プレスリリース
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             公式ブログ
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             メルカリロゴ利用ガイドライン
         .root-footer__menu--icon
           = fa_icon "twitter 3x", class: "footer__menu__box__lower--search--category--icon"
@@ -27,28 +27,28 @@
         ヘルプ&ガイド
       %ul.root-footer__menu__nav__list--outline
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             メルカリガイド
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             らくらくメルカリ便
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             ゆうゆうメルカリ便
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             大型メルカリ便
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             車体取引ガイド
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             メルカリあんしん・安全宣言
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             偽ブランド品撲滅への取り組み
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             メルカリボックス
     .root-footer__menu__nav--base
       %h2.root-footer__menu__nav--base--icon
@@ -56,43 +56,44 @@
       .root-footer__menu__nav--base--rule
         %ul.root-footer__menu__nav--base--rule__list
           %li.root-footer__menu__nav--base--rule__list--entity
-            =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav--base--rule__list--entity" do
+            =link_to "", class: "root-footer__menu__nav--base--rule__list--entity" do
               プライバシーポリシー
           %li.root-footer__menu__nav--base--rule__list--entity
-            =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav--base--rule__list--entity" do
+            =link_to "", class: "root-footer__menu__nav--base--rule__list--entity" do
               メルカリ利用規約  
           %li.root-footer__menu__nav--base--rule__list--entity
-            =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav--base--rule__list--entity" do
+            =link_to "", class: "root-footer__menu__nav--base--rule__list--entity" do
               あんしんスマホサポート制度に<br>関する利用規約
           %li.root-footer__menu__nav--base--rule__list--entity
-            =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav--base--rule__list--entity" do
+            =link_to "", class: "root-footer__menu__nav--base--rule__list--entity" do
               コンプライアンスポリシー
       .root-footer__menu__nav--base--rule
         %ul.root-footer__menu__nav--base--rule__list
           %li.root-footer__menu__nav--base--rule__list--entity
-            =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav--base--rule__list--entity" do
+            =link_to "", class: "root-footer__menu__nav--base--rule__list--entity" do
               個人データの安全管理に係る基本方針
           %li.root-footer__menu__nav--base--rule__list--entity
-            =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav--base--rule__list--entity" do
+            =link_to "", class: "root-footer__menu__nav--base--rule__list--entity" do
               特定商取引に関する表記
           %li.root-footer__menu__nav--base--rule__list--entity
-            =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav--base--rule__list--entity" do
+            =link_to "", class: "root-footer__menu__nav--base--rule__list--entity" do
               資金決済法に基づく表示
           %li.root-footer__menu__nav--base--rule__list--entity
-            =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav--base--rule__list--entity" do
+            =link_to "", class: "root-footer__menu__nav--base--rule__list--entity" do
               法令順守と犯罪抑止のために
     .root-footer__menu__nav__list
       %h2.root-footer__menu__nav__list--icon
         国
       %ul.root-footer__menu__nav__list--outline
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             日本
         %li.root-footer__menu__nav__list--outline--entity
-          =link_to "https://www.yahoo.co.jp",class: "root-footer__menu__nav__list--outline--entity" do
+          =link_to "", class: "root-footer__menu__nav__list--outline--entity" do
             united states
   .root-footer__menu__copyright
     .root-footer__menu__copyright__box
-      =image_tag  "https://web-jp-assets.mercdn.net/_next/static/images/logo-white-1a0696cf557ee1ed6f3c3444661d21ad.svg"
+      = link_to root_path do
+        =image_tag  "https://web-jp-assets.mercdn.net/_next/static/images/logo-white-1a0696cf557ee1ed6f3c3444661d21ad.svg"
       %span.root-footer__menu__copyright__box--logo
         © 2019 Mercari

--- a/app/views/joint/_header.html.haml
+++ b/app/views/joint/_header.html.haml
@@ -1,8 +1,9 @@
 %header.root-menu
   .root-menu__box
     .root-menu__box__upper
-      .root-menu__box__upper__icon 
-        = image_tag "logo-acdd90ac4f472d5a6f7a330d33ab1225.svg", size: "134x36"
+      .root-menu__box__upper__icon
+        = link_to root_path do
+          = image_tag "logo-acdd90ac4f472d5a6f7a330d33ab1225.svg", size: "134x36"
       .root-menu__box__upper__form
         %input.root-menu__box__upper--text
         %button.root-menu__box__upper--button
@@ -10,18 +11,24 @@
     .root-menu__box__lower
       .root-menu__box__lower__left
         .root-menu__box__lower__left--category
-          =link_to "https://www.yahoo.co.jp",class: "root-menu__box__lower__left--category" do
+          =link_to "" ,class: "root-menu__box__lower__left--category" do
             = fa_icon "list-ul", class: "root-menu__box__lower__left--category__icon"
             カテゴリーから探す
         .root-menu__box__lower__left--brand
-          =link_to "https://www.yahoo.co.jp",class: "root-menu__box__lower__left--brand" do
+          =link_to "" ,class: "root-menu__box__lower__left--brand" do
             = fa_icon "tag", class: "root-menu__box__lower__left--category__icon"
             ブランドから探す
       .root-menu__box__lower__right
-        =link_to new_user_registration_path,class: "root-menu__box__lower__right--sign-in" do
-          新規会員登録
-        =link_to new_user_session_path,class: "root-menu__box__lower__right--log-in" do
-          ログイン
+        - if user_signed_in?
+          = link_to mypage_path, class: "root-menu__box__lower__right__mypage" do
+            = image_tag 'user/user_photo_noimage.png', height: '32', width: '32', align: "middle", class: 'root-menu__box__lower__right__mypage__avator'
+            .root-menu__box__lower__right__mypage__text
+              マイページ
+        - else
+          =link_to new_user_registration_path,class: "root-menu__box__lower__right--sign-in" do
+            新規会員登録
+          =link_to new_user_session_path,class: "root-menu__box__lower__right--log-in" do
+            ログイン
 
   .root-short-menu
     .root-short-menu__box
@@ -29,16 +36,22 @@
         .root-short-menu__box__upper--left
           = image_tag "logo-acdd90ac4f472d5a6f7a330d33ab1225.svg", size: "134x36"
         .root-short-menu__box__upper__right
-          =link_to "新規会員登録","https://www.yahoo.co.jp",class: "root-short-menu__box__upper__right--sign-in"
-          =link_to "ログイン","https://www.yahoo.co.jp",class: "root-short-menu__box__upper__right--log-in"
+          - if user_signed_in?
+            = link_to mypage_path, class: "root-menu__box__lower__right__mypage" do
+              = image_tag 'user/user_photo_noimage.png', height: '32', width: '32', align: "middle", class: 'root-menu__box__lower__right__mypage__avator'
+          - else
+            =link_to new_user_registration_path,class: "root-short-menu__box__upper__right--sign-in" do
+              新規会員登録
+            =link_to new_user_session_path,class: "root-short-menu__box__upper__right--log-in" do
+              ログイン
       .root-short-menu__box__center
         %input.root-short-menu__box__center--text
         .root-short-menu__box__upper--button
           = fa_icon "search", class: "root-short-menu__box__upper__button__icon"
       .root-short-menu__box__lower
-        =link_to "https://www.yahoo.co.jp",class: "root-short-menu__box__lower--category" do
+        =link_to "", class: "root-short-menu__box__lower--category" do
           = fa_icon "list-ul", class: "root-menu__box__lower__left--category__icon"
           カテゴリーから探す
-        =link_to "https://news.yahoo.co.jp/",class: "root-short-menu__box__lower--brand" do
+        =link_to "", class: "root-short-menu__box__lower--brand" do
           = fa_icon "tag", class: "root-menu__box__lower__left--category__icon"
           ブランドから探す

--- a/app/views/joint/_itembox.html.haml
+++ b/app/views/joint/_itembox.html.haml
@@ -4,7 +4,7 @@
       .root-new__production__box__upper--name
         #{category}新着アイテム
       .root-new__production__box__upper--detail-path
-        =link_to "もっと見る","https://reissuerecords.net/",class:"root-new__production__box__upper--detail-path" 
+        =link_to "もっと見る","",class:"root-new__production__box__upper--detail-path"
     .root-new__production__box__group
       .root-new__production__box__group__list
         - items.each do |item|
@@ -20,4 +20,3 @@
             .root-new__production__box__group__list--text
               %span.root-new__production__box__group__list--text--span
                 = item.name
-                


### PR DESCRIPTION
#What
トップページとフッターにあるロゴにトップページのリンクを付与
ログイン後はヘッダーにあったログインボタンを表示せず、マイページリンクのボタンを表示するように変更

#Why
ユーザーが目的のリンクで移動できるようにするため、
ログイン後はログインボタンが不要で、自身のページにリンクした方が便利なため

