### PR TITLE
商品詳細ページ、商品情報テーブルの要素のテキスト長が長い時のレイアウト崩れを修正

### DIFF
--- a/app/assets/stylesheets/module/items/_detail.scss
+++ b/app/assets/stylesheets/module/items/_detail.scss
@@ -110,6 +110,7 @@
     &__table {
       float: right;
       min-width: 300px;
+      max-width: 300px;
       border: 1px $table-border solid;
       &__th {
         text-align: left;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -41,21 +41,21 @@
                 カテゴリー
               %td.item-detail__infomation__table__td
                 %p
-                  = link_to "#", class: "item-detail__infomation__table__td__link" do
+                  = link_to "", class: "item-detail__infomation__table__td__link" do
                     = @item.category&.parent&.parent&.name
                 %p
-                  = link_to "#", class: "item-detail__infomation__table__td__caterogy" do
+                  = link_to "", class: "item-detail__infomation__table__td__caterogy" do
                     = fa_icon 'angle-right', class: "item-detail__infomation__table__td__caterogy__icon"
                     = @item.category.parent&.name
                 %p
-                  = link_to "#", class: "item-detail__infomation__table__td__caterogy" do
+                  = link_to "", class: "item-detail__infomation__table__td__caterogy" do
                     = fa_icon 'angle-right', class: "item-detail__infomation__table__td__caterogy__icon"
                     = @item.category.name
             %tr
               %th.item-detail__infomation__table__th
                 ブランド
               %td.item-detail__infomation__table__td
-                = link_to "#", class: "item-detail__infomation__table__td__link" do
+                = link_to "", class: "item-detail__infomation__table__td__link" do
                   = @item.brand&.name
             %tr
               %th.item-detail__infomation__table__th
@@ -77,14 +77,14 @@
                 配送元地域
               %td.item-detail__infomation__table__td
                 %p
-                  = link_to "#", class: "item-detail__infomation__table__td__link" do
+                  = link_to "", class: "item-detail__infomation__table__td__link" do
                     = @item.prefecture.name
             %tr
               %th.item-detail__infomation__table__th
                 配送日の目安
               %td.item-detail__infomation__table__td
                 %p
-                  = link_to "#", class: "item-detail__infomation__table__td__link" do
+                  = link_to "", class: "item-detail__infomation__table__td__link" do
                     = @item.deliver_day.day
       -# 商品金額
       .item-detail__amount
@@ -115,7 +115,7 @@
           %li.item-detail__footer__button-list__button
             = fa_icon 'flag-o', class: "item-detail__footer__button-list__button__icon"
             不適切な商品の報告
-        = link_to "#", class:"item-detail__footer__link" do
+        = link_to "", class:"item-detail__footer__link" do
           = fa_icon 'lock', class: "item-detail__footer__link__icon"
           あんしん・あんぜんへの取り組み
     -# 出品者のみ商品状態変更ボタンを表示
@@ -171,7 +171,7 @@
     -# 同じカテゴリーの商品
     .item-others
       %h2.item-others__headline
-        = link_to "#", class: "item-others__headline--link" do
+        = link_to "", class: "item-others__headline--link" do
           - if @item.category.name == "その他"
             = "#{@item.category.parent.name}その他の商品"
           - else


### PR DESCRIPTION
# What
商品詳細ページでカテゴリー名が長い商品を表示した際に、
商品情報を表示するテーブルの横幅が広がり、floatの余白に入りきらず折り返し表示されてしまう不具合を修正。

# Why
バグ修正のため