### PR TITLE
ログアウトページのマークアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@
  @import "./module/users/user-notice";
  @import "./module/users/user-navigation";
  @import "./module/users/profiles";
+ @import "./module/users/logout";
  @import "./module/cards";
  @import "./module/delivery_address";
  @import "./module/deals/deals";

--- a/app/assets/stylesheets/module/users/_logout.scss
+++ b/app/assets/stylesheets/module/users/_logout.scss
@@ -1,0 +1,13 @@
+.user-logout {
+  background: $background-white;
+  padding: 64px 192px;
+  box-sizing: border-box;
+  &__button {
+    @include red-button;
+    text-align: center;
+    &:hover {
+      background: #F28A86;
+      transition: background 0.3s;
+    }
+  }
+}

--- a/app/assets/stylesheets/test.scss
+++ b/app/assets/stylesheets/test.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the test controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -1,4 +1,0 @@
-class TestController < ApplicationController
-  def index
-  end
-end

--- a/app/views/mypages/logout.html.haml
+++ b/app/views/mypages/logout.html.haml
@@ -2,7 +2,11 @@
 = render 'users/user-breadcrumb', {symbol: :logout_mypage}
 .user-wrapper
   %main.user-main
-    -# TODO: パンくず確認用に未実装ページのビューを作成、別タスクで実装する
+    .user-container
+      .user-logout
+        = link_to destroy_user_session_path, method: :delete do
+          .user-logout__button
+            ログアウト
     -# ナビゲーションバー
     = render 'users/user-navigation'
 = render 'joint/app__dl'

--- a/app/views/test/index.html.haml
+++ b/app/views/test/index.html.haml
@@ -1,1 +1,0 @@
-= link_to "ログアウト",destroy_user_session_path, method: :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,6 @@ Rails.application.routes.draw do
 
   resources :users, only:[:show]
 
-  resources :test,only:[:index]
-
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
 


### PR DESCRIPTION
# What
ログアウトページをマークアップする
# Why
サービスを利用しない時にユーザーがログアウトをすることで、
悪意のある他人に利用者のPCを使用してサービスを使うリスクを減らすため。

## スクリーンショット
![Screenshot_2019-11-09 FreemarketSample54b](https://user-images.githubusercontent.com/1934766/68521269-d0f80100-02e2-11ea-8ba4-a1d077990302.png)