### PR TITLE
新規登録ページバリデーションエラーの表示修正

### DIFF
--- a/app/assets/javascripts/payjp_cards.js
+++ b/app/assets/javascripts/payjp_cards.js
@@ -21,6 +21,13 @@ $(document).on('turbolinks:load', function() {
     };
     //エラーメッセージ消去
     removeErrorMessage();
+    // javascriptによるバリデーション（簡易チェック）
+    if(!cardValid(card)) {
+      // preventDefaultによるdisableがメソッドを抜けないと有効にならないので少し経ってからdisableを消去する
+      setTimeout(function() {
+        form.find('.card-container__form__field__button').prop('disabled', false)}, 500);
+      return;
+    }
     // トークンを取得
     Payjp.createToken(card, function(s, response) {
       // トークン取得エラー
@@ -45,6 +52,9 @@ $(document).on('turbolinks:load', function() {
         var token = response.id;
         // payjp.jsから送られたカードトークンをformに追加してサーバーへPOST
         form.append($('<input type="hidden" name="card_token" />').val(token));
+        // カード情報をサーバーサイドに送らないためにカード情報入力をクリア
+        $('#payjp_card_number').val('');
+        $('#payjp_card_cvc').val('');
         form.get(0).submit();
       }
       //ボタン有効化
@@ -52,10 +62,37 @@ $(document).on('turbolinks:load', function() {
     });
   });
 
-
   // エラーメッセージ消去
   function removeErrorMessage() {
     $(".card-error_message").remove();
+  }
+
+  //カードバリデーション
+  function cardValid(card) {
+    var valid = true;
+    // カード番号
+    var cardRe = new RegExp('[0-9]{12,20}');
+    if (!cardRe.test(card.number))
+    {
+      valid = false;
+      buildInvalidNumberErrorMessage();
+    }
+    // 有効期限
+    var now = new Date();
+    if(parseInt(card.exp_year) < now.getFullYear()
+      || (parseInt(card.exp_year) === now.getFullYear() && parseInt(card.exp_month) < now.getMonth() + 1))
+    {
+      valid = false;
+      buildInvalidExpiredErrorMessage();
+    }
+    // セキュリティーコード
+    var cvcRe = new RegExp('[0-9]{3,4}');
+    if (!cvcRe.test(card.cvc))
+    {
+      valid = false;
+      buildInvalidCVCErrorMessage();
+    }
+    return valid;
   }
 
   // エラーメッセージ表示（カード番号）

--- a/app/assets/javascripts/test.coffee
+++ b/app/assets/javascripts/test.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/module/devise/_phone_number.scss
+++ b/app/assets/stylesheets/module/devise/_phone_number.scss
@@ -1,5 +1,6 @@
 .phone_number-wrapper{
   background-color:$background-smokewhite;
+  min-height: calc(100vh - 128px);
 }
 
 .phone_number-contents{

--- a/app/assets/stylesheets/module/devise/_registration_create.scss
+++ b/app/assets/stylesheets/module/devise/_registration_create.scss
@@ -1,5 +1,6 @@
 .registration-create-wrapper{
   background-color:$background-smokewhite;
+  min-height: calc(100vh - 128px);
 }
 
 .registration-create-contents{

--- a/app/assets/stylesheets/module/devise/_top.scss
+++ b/app/assets/stylesheets/module/devise/_top.scss
@@ -4,6 +4,7 @@
 
 .registration-top-wrapper{
   background-color:$background-smokewhite;
+  min-height: 100vh;
 }
 
 .registration-top-contents{

--- a/app/controllers/payjp_cards_controller.rb
+++ b/app/controllers/payjp_cards_controller.rb
@@ -16,8 +16,7 @@ class PayjpCardsController < ApplicationController
   end
 
   def create
-    # formのパラメータとpayjp.jsのカードtokenを取得
-    @payjp_card = PayjpCard.new(payjp_card_params)
+    # payjp.jsのカードtokenを取得
     card_token = token_params[:card_token]
     # PAY.JPの顧客情報IDを既にデータベースに登録しているかチェック
     @credit_card = current_user.credit_card

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -26,6 +26,7 @@ class DeliveryAddress < ApplicationRecord
   belongs_to :user
   belongs_to_active_hash :prefecture
 
+  # 都道府県入力バリデーション
   def check_prefecture
     if prefecture_id.nil?
       errors.add(:prefecture_id, "を選択してください")

--- a/app/models/personal.rb
+++ b/app/models/personal.rb
@@ -12,6 +12,8 @@ class Personal < ApplicationRecord
   validates :first_name_kana, presence: true
   validates :zip_code,length: {maximum: 8}
   validates :zip_code,presence: true
+  validates :zip_code, format: {message: "を正しく入力してください", with: /\A[0-9]{3}-[0-9]{4}\z/}
+  validate :check_prefecture
   validates :city,length: {maximum: 50}
   validates :city,presence: true
   validates :address,length: {maximum: 100}
@@ -21,14 +23,20 @@ class Personal < ApplicationRecord
   validates :cellular_phone_number,length: {maximum: 35}
   validates :cellular_phone_number, presence: true
   validate :check_phone_number
-  validates :birthdate, presence: true 
+  validates :birthdate, presence: true
   #カタカナとひらがな以外のデータを制限
   validates :first_name_kana, presence: true, format: { with: /\A[\p{katakana}\p{hiragana}\p{blank}ー－]+\z/  ,message: "はひらがなかカタカナで入力してください"}
   validates :last_name_kana, presence: true, format: { with: /\A[\p{katakana}\p{hiragana}\p{blank}ー－]+\z/ ,message: "はひらがなかカタカナで入力してください"}
-
+  #Association
   belongs_to :user
-  
   belongs_to_active_hash :prefecture
+
+  # 都道府県入力バリデーション
+  def check_prefecture
+    if prefecture_id.nil?
+      errors.add(:prefecture_id, "を選択してください")
+    end
+  end
 
   def check_phone_number
     unless cellular_phone_number.blank? || Phonelib.valid_for_country?(cellular_phone_number, :jp)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,:confirmable 
-
+         :recoverable, :rememberable, :validatable, :confirmable
+  #Association
   has_one :profile, dependent: :destroy
   has_one :personal, dependent: :destroy
   accepts_nested_attributes_for :personal
@@ -17,8 +17,6 @@ class User < ApplicationRecord
   has_many :item_comments
   has_many :item_likes
   has_one :credit_card, dependent: :destroy
-
-  validates :password,    length: { minimum: 7 }
 
   # 購入可能な情報を保持しているか判定する
   def can_purchase?

--- a/app/views/devise/registrations/step1.html.haml
+++ b/app/views/devise/registrations/step1.html.haml
@@ -114,8 +114,8 @@
           ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
         %p.registration-form-caution-text
           「次へ進む」のボタンを押すことにより、
-          %span 
-            =link_to "利用規約","https://www.yahoo.co.jp",class:"registration-form-right--link" 
+          %span
+            =link_to "利用規約", "", class:"registration-form-right--link"
           に同意したものとみなします
         %div
           .registration-actions
@@ -125,4 +125,4 @@
             本人情報の登録について
             = fa_icon "angle-right", class: "registration-form-right--link"
   .registration-footer
-  = render 'deals/footer' 
+  = render 'deals/footer'

--- a/app/views/devise/registrations/step2.html.haml
+++ b/app/views/devise/registrations/step2.html.haml
@@ -2,11 +2,11 @@
 .phone_number-wrapper
   .phone_number-contents
     %h2.registration_title 電話番号の確認
-    = form_with model: resource,as: resource_name,local: true, url: step3_path(resource_name), method: :get, id: "phone_number-form", class: "phone_number-form" do |f|
+    = form_with model: resource.personal, as: resource_name, local: true, url: step3_path(resource_name), method: :get, id: "phone_number-form", class: "phone_number-form" do |f|
       .phone_number__section
         =f.label "携帯電話の番号"
         %br
-        = f.text_field :cellular_phone_number, placeholder: "携帯電話の番号を入力", maxlength:16, class: "phone_number-form__input"
+        = f.text_field :cellular_phone_number, placeholder: "携帯電話の番号を入力", maxlength:35, class: "phone_number-form__input"
         %br
         - if resource.errors.full_messages_for(:"personal.cellular_phone_number").any?
           %ul
@@ -16,4 +16,4 @@
         %p.phone_number-caution 本人確認のため、携帯電話のSMS(ショートメッセージサービス)を利用して認証を行います。
       = f.submit "SMSを送信する",class:"registration-btn"
       %p.phone_number-caution※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。
-  = render 'deals/footer'  
+  = render 'deals/footer'

--- a/app/views/devise/registrations/step3.html.haml
+++ b/app/views/devise/registrations/step3.html.haml
@@ -2,13 +2,13 @@
 .home_address-wrapper
   .home_address-contents
     %h2.registration_title お届け先住所入力
-    = form_with model: resource,as: resource_name,local: true, url: step4_path(resource_name), method: :get, id: "home_address-form", class: "home_address-form" do |f|
+    = form_with model: resource.personal, as: resource_name,local: true, url: step4_path(resource_name), method: :get, id: "home_address-form", class: "home_address-form" do |f|
       .home_address-section
         =f.label "郵便番号"
         %span.form--required
           必須
         %br
-        = f.text_field :zip_code, placeholder: "例)123-456", maxlength:16, class: "home_address-form__input"
+        = f.text_field :zip_code, placeholder: "例)123-4567", maxlength:8, class: "home_address-form__input"
         %br/
         - if resource.errors.full_messages_for(:"personal.zip_code").any?
           %ul
@@ -32,7 +32,7 @@
         %span.form--required
           必須
         %br
-        = f.text_field :city, placeholder: "名古屋市", maxlength:50, class: "home_address-form__input"
+        = f.text_field :city, placeholder: "例）横浜市緑区", maxlength:50, class: "home_address-form__input"
         %br/
         - if resource.errors.full_messages_for(:"personal.city").any?
           %ul
@@ -44,7 +44,7 @@
         %span.form--required
           必須
         %br
-        = f.text_field :address, placeholder: "栄", maxlength:100, class: "home_address-form__input"
+        = f.text_field :address, placeholder: "例）青山1-1-1", maxlength:100, class: "home_address-form__input"
         %br/
         - if resource.errors.full_messages_for(:"personal.address").any?
           %ul
@@ -54,6 +54,6 @@
       .home_address-section
         =f.label "建物名"
         %br
-        = f.text_field :building, placeholder: "○○ビル", maxlength:100, class: "home_address-form__input"
+        = f.text_field :building, placeholder: "例）柳ビル103", maxlength:100, class: "home_address-form__input"
       = f.submit "次へ進む",class:"registration-btn"
-  = render 'deals/footer'  
+  = render 'deals/footer'

--- a/app/views/payjp_cards/_devise_form.html.haml
+++ b/app/views/payjp_cards/_devise_form.html.haml
@@ -4,7 +4,7 @@
       = f.label :number
       %span.form--required
         必須
-    = f.text_field :number, placeholder: "半角数字のみ", maxlength:16, class: "card-container__form__field__text_field"
+    = f.text_field :number, placeholder: "半角数字のみ", maxlength:16, autocomplete: "off", class: "card-container__form__field__text_field"
     %ul.card-container__form__field__cardlist
       %li.card-container__form__field__cardlist__carditem
         = image_tag "cards/visa.svg", class: "card-container__form__field__cardlist__carditem__image"

--- a/app/views/payjp_cards/_form.html.haml
+++ b/app/views/payjp_cards/_form.html.haml
@@ -4,7 +4,7 @@
       = f.label :number
       %span.form--required
         必須
-    = f.text_field :number, placeholder: "半角数字のみ", maxlength:16, class: "card-container__form__field__text_field"
+    = f.text_field :number, placeholder: "半角数字のみ", maxlength:16, autocomplete: "off", class: "card-container__form__field__text_field"
     %ul.card-container__form__field__cardlist
       %li.card-container__form__field__cardlist__carditem
         = image_tag "cards/visa.svg", class: "card-container__form__field__cardlist__carditem__image"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -168,7 +168,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,8 +23,14 @@ ja:
         first_name_kana: 名（カナ）
         last_name_kana: 姓（カナ）
         birthdate: 生年月日
+        zip_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        address: 番地
+        building: 建物名
+        cellular_phone_number: 携帯電話の番号
       user/profile:
-         nickname: ニックネーム        
+         nickname: ニックネーム
       profile:
         nickname: ニックネーム
         introduction: プロフィール文
@@ -43,7 +49,7 @@ ja:
         deal: 取引状況
         seller: 出品者
         item_images: 画像
-      item/item_images: 
+      item/item_images:
         image: ''
       delivery_address:
         last_name: お名前（姓）


### PR DESCRIPTION
# What
新規登録ページの２ページ目以降のステップで、
バリデーションエラーが表示されていない現象の修正。
またバリデーション周りの実装抜けや日本語化抜けを修正した。

# Why
サービス登録者が正しく入力できていない箇所と理由を明示的に伝えるため。
