### PR TITLE
商品編集ページにカテゴリの入力とインクリメンタルサーチを追加

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,4 +1,12 @@
 $(document).on('turbolinks:load', function() {
+
+  //商品編集ページの時既にブランド入力エリアが存在するので、
+  //インクリメンタルサーチ機能を追加する
+  var re = new RegExp('/items/[0-9]+/edit$');
+  if(re.test(location.pathname)) {
+    addIncrementalSearch();
+  }
+
   function appendOption(category) {
     var html = `<option value="${category.id}">${category.name}</option>`;
     return html;
@@ -37,6 +45,11 @@ $(document).on('turbolinks:load', function() {
     $('#items-sell-container-category').after(brandInputHTML);
 
     // インクリメンタルサーチ処理を追加
+    addIncrementalSearch();
+  }
+
+  // インクリメンタルサーチ処理を追加
+  function addIncrementalSearch() {
     $("#item_brand_input").on("keyup", function() {
       var input = $("#item_brand_input").val();
       if (input.length == 0)
@@ -66,7 +79,7 @@ $(document).on('turbolinks:load', function() {
     });
   }
 
-    // インクリメンタルサーチ結果を入れるリストのマークアップを取得、無ければ作成して追加する
+  // インクリメンタルサーチ結果を入れるリストのマークアップを取得、無ければ作成して追加する
   function appendBrandSearchResults(brands) {
     // 検索結果を入れるリストの用意
     var search_results_list = $("#brand-incremental-search-results");

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -85,6 +85,8 @@ class ItemsController < ApplicationController
     exist_ids = registered_image_params[:ids].map(&:to_i)
     # 登録済画像が残っていない場合(配列に0が格納されている)、配列を空にする
     exist_ids.clear if exist_ids[0] == 0
+    #入力されたブランド名がbrandsテーブルに存在する場合、ブランドをセット
+    @item.brand = Brand.find_by(name:brand_name_params[:brand_name]) unless brand_name_params.empty?
 
     # 新規登録、登録済画像が1枚も残っていない場合は、元の画面がredirectする
     unless exist_ids.length == 0 && params[:item][:item_images_attributes].nil?

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -47,7 +47,7 @@
         %section.items-sell-content__section.clearfix
           %h3.item__heading 商品の詳細
           .items-sell-container__box
-            .items-sell-container__form__field
+            .items-sell-container__form__field#items-sell-container-category
               .items-sell-container__form__field__label
                 = f.label :category_id, "カテゴリー"
                 %span.form--required
@@ -63,6 +63,13 @@
                     = f.select :category, {}, {}, {id:"grandchild_category", class:"items-sell-container__form__field__input-field", name:'item[category_id]'} do
                       - @category_grandchild_array.each do |c|
                         = content_tag(:option, c.first, value: c.last)
+            .items-sell-container__form__field#brand_wrapper
+              .items-sell-container__form__field__label
+                = f.label :brand_name, "ブランド"
+                %span.form--optional
+                  任意
+              = f.text_field :brand_name, value: @item.brand&.name, placeholder: "例）シャネル", id:"item_brand_input", class:"items-sell-container__form__field__input-field", autocomplete: "off"
+            
             .items-sell-container__form__field
               .items-sell-container__form__field__label
                 = f.label :item_state_id, "商品の状態"


### PR DESCRIPTION
# What
商品出品ページに実装していたブランド名の入力と、
ブランド名入力欄のインクリメンタルサーチを追加する。

# Why
販売者が販売商品のブランド名を入力することで、
購入者側ではブランドによる一覧表示や検索ができるようにするため（現時点では未実装）