### PR TITLE
商品編集機能の改善#2

### DIFF
--- a/app/assets/stylesheets/module/items/_items.scss
+++ b/app/assets/stylesheets/module/items/_items.scss
@@ -38,10 +38,13 @@
 
 .preview {
   display: inline-block;
+  height: 100%;
   width: 100%;
 }
 
 .preview img {
+  object-fit: contain;
+  height: calc(100% - 44px);
   width: 100%;
   float: left;
   cursor: move;
@@ -52,8 +55,8 @@
 }
 
 .img-view {
-  width: 116px;
   height: 162px;
+  width: 116px;
   margin: 0 10px 10px 0;
   display: inline-block;
 }

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -127,11 +127,11 @@
             .margin-calculation
               販売手数料(10%)
               .margin-calculation__result
-                \-
+                ¥#{(@item.amount / 10).to_s(:delimited)}
             .profit-calculation
               販売利益
               .profit-calculation__result
-                \-
+                ¥#{(@item.amount - @item.amount / 10).to_s(:delimited)}
         %section.items-sell-content__section.clearfix
           %p 
             禁止されている出品、行為を必ずご確認ください。


### PR DESCRIPTION
## WHAT
以下2点の実装。
商品出品、編集のプレビュー画像サイズを縦横固定
商品編集のビューを読み込んだ時点(JS発火前)で販売手数料を表示

## WHY
根幹である商品編集機能のユーザビリティ向上のため