### PR TITLE
マイページ、商品購入ページにフラッシュメッセージを追加

### DIFF
--- a/app/controllers/deals/deals_delivery_addresses_controller.rb
+++ b/app/controllers/deals/deals_delivery_addresses_controller.rb
@@ -13,8 +13,9 @@ class Deals::DealsDeliveryAddressesController < DeliveryAddressesController
     @delivery_address = DeliveryAddress.new(address_params)
     @delivery_address.user = current_user
     if @delivery_address.save
-      redirect_to new_item_purchase_path
+      redirect_to(new_item_purchase_path, notice: "配送先を登録しました")
     else
+      flash[:alert] = '入力内容に不備があります'
       render :new
     end
   end
@@ -24,8 +25,9 @@ class Deals::DealsDeliveryAddressesController < DeliveryAddressesController
     @delivery_address = DeliveryAddress.find(params[:id])
     if @delivery_address.user_id == current_user.id
       if @delivery_address.update(address_params)
-        redirect_to new_item_purchase_path
+        redirect_to(new_item_purchase_path, notice: "配送先を変更しました")
       else
+        flash[:alert] = '入力内容に不備があります'
         render :new
       end
     end

--- a/app/controllers/deals/purchase_controller.rb
+++ b/app/controllers/deals/purchase_controller.rb
@@ -9,7 +9,7 @@ class Deals::PurchaseController < ApplicationController
 
   def new
     # 商品が出品中でないのにリクエストが来た時商品詳細ページへリダイレクト
-    return redirect_to item_path(@item) unless @item.sales_state_id == 1
+    return redirect_to(item_path(@item), alert:"商品が出品中でないため購入できません") unless @item.sales_state_id == 1
     # ログインユーザーのカード情報を取得する
     @credit_card = current_user.credit_card
     @payjp_card = @credit_card&.getPayjpDefaultCard
@@ -17,9 +17,9 @@ class Deals::PurchaseController < ApplicationController
 
   def create
     # 商品が出品中でないのに購入リクエストが来た時商品詳細ページへリダイレクト
-    return redirect_to item_path(@item) unless @item.sales_state_id == 1
+    return redirect_to(item_path(@item), alert:"商品が出品中でないため購入できません") unless @item.sales_state_id == 1
     # 自分の出品商品なのに購入リクエストが来た時商品詳細ページへリダイレクト
-    return redirect_to item_path(@item) if @item.seller == current_user
+    return redirect_to(item_path(@item), alert:"自分が出品した商品は購入できません") if @item.seller == current_user
     #トランザクション開始
     ActiveRecord::Base.transaction do
       begin
@@ -50,6 +50,7 @@ class Deals::PurchaseController < ApplicationController
         end
       rescue => error
         # 例外発生時は購入画面に戻りロールバックする
+        flash.now[:alert] = '商品購入ができませんでした。申し訳ありませんがもう一度操作してください'
         render :new
         raise ActiveRecord::Rollback
       end

--- a/app/controllers/mypage/personals_controller.rb
+++ b/app/controllers/mypage/personals_controller.rb
@@ -9,8 +9,9 @@ class Mypage::PersonalsController < ApplicationController
 
   def update
     if @personal.update(profile_param)
-      redirect_to edit_mypage_personals_path
+      redirect_to(mypage_path, notice: "本人情報を登録しました")
     else
+      flash[:alert] = '入力内容に不備があります'
       render :edit
     end
   end

--- a/app/controllers/mypage/profiles_controller.rb
+++ b/app/controllers/mypage/profiles_controller.rb
@@ -15,8 +15,9 @@ class Mypage::ProfilesController < ApplicationController
     return redirect_to edit_mypage_profiles_path if current_user.profile
     @profile = current_user.build_profile(profile_param)
     if @profile.save
-      redirect_to mypage_path
+      redirect_to(mypage_path, notice: "プロフィールを作成しました")
     else
+      flash[:alert] = '入力内容に不備があります'
       render :new
     end
   end
@@ -30,9 +31,10 @@ class Mypage::ProfilesController < ApplicationController
     # プロフィールを作成していないのに編集リクエストが来た際にはnewアクションにリダイレクト
     return redirect_to new_mypage_profiles_path unless @profile
     if @profile.update(profile_param)
-      redirect_to mypage_path
+      redirect_to(mypage_path, notice: "プロフィールを更新しました")
     else
-      render :new
+      flash[:alert] = '入力内容に不備があります'
+      render :edit
     end
   end
 

--- a/app/views/layouts/_flash.html.haml
+++ b/app/views/layouts/_flash.html.haml
@@ -1,3 +1,3 @@
 .notification
-  -flash.each do |key, value|
+  - flash.each do |key, value|
     = content_tag :div, value, class: key

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,6 +11,6 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     .header.container
-      =render partial: "layouts/flash"
-    =yield
-   
+      = render partial: "layouts/flash"
+    = yield
+

--- a/app/views/layouts/deals_payjp_cards.html.haml
+++ b/app/views/layouts/deals_payjp_cards.html.haml
@@ -10,4 +10,6 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'https://js.pay.jp/'
   %body
+    .header.container
+      = render partial: "layouts/flash"
     = yield

--- a/app/views/layouts/payjp_cards.html.haml
+++ b/app/views/layouts/payjp_cards.html.haml
@@ -10,4 +10,6 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'https://js.pay.jp/'
   %body
+    .header.container
+      = render partial: "layouts/flash"
     = yield


### PR DESCRIPTION
# What
フラッシュメッセージを作成した購入ページ、編集ページに対応させる。

# Why
利用者が行った操作に対する結果を表示することで、
システム側で何が行われたをわかりやすくするため。

## 対応箇所
出品商品確認ページ（出品状態変更、商品削除）
商品購入確認ページ（購入可能条件確認）
商品購入確認配送先登録ページ
商品購入カード登録ページ
マイページプロフィール変更ページ
マイページ個人情報登録ページ
マイページカード登録ページ