### PR TITLE
商品出品機能の改善

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,11 +1,7 @@
 $(document).on('turbolinks:load', function() {
 
-  //商品編集ページの時既にブランド入力エリアが存在するので、
   //インクリメンタルサーチ機能を追加する
-  var re = new RegExp('/items/[0-9]+/edit$');
-  if(re.test(location.pathname)) {
-    addIncrementalSearch();
-  }
+  addIncrementalSearch();
 
   function appendOption(category) {
     var html = `<option value="${category.id}">${category.name}</option>`;

--- a/app/assets/javascripts/dropzone.js
+++ b/app/assets/javascripts/dropzone.js
@@ -8,6 +8,13 @@ $(document).on('turbolinks:load', function() {
   var preview = $('.preview');
   var input_area = $('.input_area');
 
+  // カテゴリが既に入力されている場合、入力された値をビューへ渡す
+  if($("#grandchild_category").length !== 0) {
+    $("#parent_category").val(gon.parent_category);
+    $("#child_category").val(gon.child_id);
+    $("#grandchild_category").val(gon.grandchild_category);
+  };
+
   // DB保存に失敗(Rollback)した際に残っている、動的に生成したinputタグを削除する
   $(document).ready(function(){
     for (var i = preview.length; i > 1; i--) {

--- a/app/assets/javascripts/profit_calculation.js
+++ b/app/assets/javascripts/profit_calculation.js
@@ -1,5 +1,5 @@
 $(document).on('turbolinks:load', function() {
-  $(document).on('keyup', '.item-value', function(event) {
+  $(document).on('keyup change', '.item-value', function(event) {
     var price = $(this).val();
 
     if(price >= 300 && price <= 9999999) {
@@ -9,7 +9,6 @@ $(document).on('turbolinks:load', function() {
       profit = '¥' + String(profit).replace(/(\d)(?=(\d\d\d)+$)/g, '$1,');
       $('.margin-calculation__result').html(margin);
       $('.profit-calculation__result').html(profit);
-
     } 
     else {
       $('.margin-calculation__result').html("-");

--- a/app/assets/stylesheets/config/_validation.scss
+++ b/app/assets/stylesheets/config/_validation.scss
@@ -2,6 +2,13 @@ input[type="text"].validation-error {
   border: solid 1px #ea352d;
 }
 
+input[type="number"].validation-error {
+  border: solid 1px #ea352d;
+}
+div.validation-error {
+  border: solid 1px #ea352d;
+}
+
 select.validation-error {
   border: solid 1px #ea352d;
 }

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -16,9 +16,15 @@
             = f.fields_for :item_images do |item_image|
               .preview
                 = item_image.label :image, class: "dropzone-box", for: "upload-image-0" do
-                  .input_area.items-sell-container__dropzone0
-                    %p.image-upload-text ここをクリックして画像をアップロード
-                    = item_image.file_field :image, style: "display: none;", name: 'item[item_images_attributes][0][image]', id: "upload-image-0", class: "upload-image {validation-error if @item.errors.full_messages_for(:item_images).present?}", 'data-image': 0
+                  - if @item.errors.full_messages_for(:item_images).present?
+                    .input_area.items-sell-container__dropzone0.validation-error
+                      %p.image-upload-text ここをクリックして画像をアップロード
+                      = item_image.file_field :image, style: "display: none;", name: 'item[item_images_attributes][0][image]', id: "upload-image-0", class: "upload-image", 'data-image': 0
+                  - else
+                    .input_area.items-sell-container__dropzone0
+                      %p.image-upload-text ここをクリックして画像をアップロード
+                      = item_image.file_field :image, style: "display: none;", name: 'item[item_images_attributes][0][image]', id: "upload-image-0", class: "upload-image", 'data-image': 0
+                .validation-error__text
                   - if @item.errors.full_messages_for(:item_images).length == 2
                     = @item.errors.full_messages_for(:item_images)[1]
                   - else
@@ -34,7 +40,7 @@
                 必須
             = f.text_field :name, placeholder: "商品名(必須 40文字まで)", class:"items-sell-container__form__field__input-field"
             - if @item.errors.full_messages_for(:name).present?
-              %p 入力してください
+              %p.validation-error__text 入力してください
           .items-sell-container__form__description
             .items-sell-container__form__description__label
               = f.label :description, "商品の説明"
@@ -42,7 +48,7 @@
                 必須
             = f.text_area :description, placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", class:"items-sell-container__form__description__text_field"
             - if @item.errors.full_messages_for(:description).present?
-              %p 入力してください
+              %p.validation-error__text 入力してください
 
         %section.items-sell-content__section.clearfix
           %h3.item__heading 商品の詳細
@@ -53,16 +59,36 @@
                 %span.form--required
                   必須
               = f.select :category, @category_parent_array, {}, id:"parent_category", class:"items-sell-container__form__field__input-field"
+              - if @item.errors.full_messages_for(:category).present?
+                %p.validation-error__text 選択してください
               .items-sell-detail__category
-
+                .items-sell-container__form__field-detail#children_wrapper
+                  - unless @item.category.nil?
+                    %div{id: "#{Category.find_by(id: @item.category_id).parent.nil? ? "none" : "children_wrapper"}"}
+                      = f.select :category, {}, {}, {id:"child_category", class:"items-sell-container__form__field__input-field", name:'item[category_id]'} do
+                        - @category_child_array.each do |c|
+                          = content_tag(:option, c.first, value: c.last)
+                .items-sell-container__form__field-detail#grandchildren_wrapper
+                  - unless @item.category.nil?
+                    %div{id: "#{Category.find_by(id: @item.category_id).parent.parent.nil? ? "none" : "grandchildren_wrapper"}"}
+                      = f.select :category, {}, {}, {id:"grandchild_category", class:"items-sell-container__form__field__input-field", name:'item[category_id]'} do
+                        - @category_grandchild_array.each do |c|
+                          = content_tag(:option, c.first, value: c.last)
+            - unless Category.find_by(id: @item.category_id)&.parent&.parent.nil?
+              .items-sell-container__form__field#brand_wrapper
+                .items-sell-container__form__field__label
+                  = f.label :brand_name, "ブランド"
+                  %span.form--optional
+                    任意
+                = f.text_field :brand_name, value: @item.brand&.name, placeholder: "例）シャネル", id:"item_brand_input", class:"items-sell-container__form__field__input-field", autocomplete: "off"
             .items-sell-container__form__field
               .items-sell-container__form__field__label
                 = f.label :item_state_id, "商品の状態"
                 %span.form--required
                   必須
-              = f.collection_select :item_state_id, ItemState.all, :id, :state, {include_blank: "---"}, {class:"items-sell-container__form__field__input-field"}
+              = f.collection_select :item_state_id, ItemState.all, :id, :state, {include_blank: "---"}, {class:"items-sell-container__form__field__input-field #{"validation-error" if @item.errors.full_messages_for(:item_state).present?}"}
               - if @item.errors.full_messages_for(:item_state).present?
-                %p 入力してください
+                %p.validation-error__text 入力してください
 
         %section.items-sell-content__section.clearfix
           %h3.delivery__heading 配送について
@@ -74,10 +100,19 @@
                 = f.label :deliver_expend_id, "配送料の負担"
                 %span.form--required
                   必須
-              = f.collection_select :deliver_expend_id, DeliverExpend.all, :id, :expend, {include_blank: "---"}, {class:"items-sell-container__form__field__input-field"}
+              = f.collection_select :deliver_expend_id, DeliverExpend.all, :id, :expend, {include_blank: "---"}, {class:"items-sell-container__form__field__input-field #{"validation-error" if @item.errors.full_messages_for(:deliver_expend).present?}"}
               - if @item.errors.full_messages_for(:deliver_expend).present?
-                %p 選択してください
+                %p.validation-error__text 選択してください
             #items-sell-delivery-method
+              - unless @item.deliver_expend.nil?
+                %div{class: "items-sell-container__form__field", id: @item.deliver_expend.nil? ? "none" : "deliver_method"}
+                  .items-sell-container__form__field__label
+                    = f.label :deliver_method_id, "配送の方法"
+                    %span.form--required
+                      必須
+                  = f.collection_select :deliver_method_id, @deliver_methods, :id, :method, {include_blank: "---"}, {class:"items-sell-container__form__field__input-field"}
+                  - if @item.errors.full_messages_for(:deliver_method).present?
+                    %p.validation-error__text 選択してください
             .items-sell-container__form__field
               .items-sell-container__form__field__label
                 = f.label :prefecture_id, "発送元の地域"
@@ -85,15 +120,15 @@
                   必須
               = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "---"}, {class:"items-sell-container__form__field__input-field"}
               - if @item.errors.full_messages_for(:prefecture_id).present?
-                %p 選択してください
+                %p.validation-error__text 選択してください
             .items-sell-container__form__field
               .items-sell-container__form__field__label
                 = f.label :deliver_day_id, "発送までの日数"
                 %span.form--required
                   必須
-              = f.collection_select :deliver_day_id, DeliverDay.all, :id, :day, {include_blank: "---"}, {class:"items-sell-container__form__field__input-field"}
+              = f.collection_select :deliver_day_id, DeliverDay.all, :id, :day, {include_blank: "---"}, {class:"items-sell-container__form__field__input-field #{"validation-error" if @item.errors.full_messages_for(:deliver_day).present?}"}
               - if @item.errors.full_messages_for(:deliver_day).present?
-                %p 選択してください
+                %p.validation-error__text 選択してください
 
         %section.items-sell-content__section.clearfix
           %h3.price__heading 販売価格(300〜9,999,999)
@@ -105,17 +140,23 @@
                 = f.label :amount, "価格"
                 %span.form--required
                   必須
-              = f.number_field :amount, placeholder: "例）300", class: "items-sell-container__form__field__input-field item-value"
+              = f.number_field :amount, placeholder: "例）300", class: "items-sell-container__form__field__input-field item-value #{"validation-error" if @item.errors.full_messages_for(:amount).present?}", max: 9999999
               - if @item.errors.full_messages_for(:amount).present?
-                %p 300以上9999999以下で入力してください
+                %p.validation-error__text 300以上9999999以下で入力してください
             .margin-calculation
               販売手数料(10%)
               .margin-calculation__result
-                \-
+                - unless @item.amount.nil?
+                  ¥#{(@item.amount / 10).to_s(:delimited)}
+                - else 
+                  \-
             .profit-calculation
               販売利益
               .profit-calculation__result
-                \-
+                - unless @item.amount.nil?
+                  ¥#{(@item.amount - @item.amount / 10).to_s(:delimited)}
+                - else
+                  \-
         %section.items-sell-content__section.clearfix
           %p 
             禁止されている出品、行為を必ずご確認ください。


### PR DESCRIPTION
## WHAT

①JSで作成するフォームについては、ビューへ記載していなかったため、
renderされると入力した値が消えていた。
バリデーションエラーsaveに失敗、renderでビューを読み直した場合でも、
以下の項目を表示できるようにビューへ追記。
・カテゴリー
・ブランド
・配送の方法
②renderされた際に、商品価格の値が入力されていた場合、
手数料の計算結果が表示されるよう修正。

③バリデーションエラーが発生した場合、エラーメッセージ、
枠の色を赤くするように全フォーム統一した。

## WHY
ユーザビリティ向上の為。