### PR TITLE
お届け先登録のエラー修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@
 
 ## categoriesテーブル（カテゴリー）
 
-経路列挙モデル
+経路列挙モデルテーブル(gem ancestry)を使用
+
 |属性|Column|Type|Options|
 |---|---|---|---|
 |カテゴリ名|name|string|null: false|

--- a/app/controllers/deals/deals_delivery_addresses_controller.rb
+++ b/app/controllers/deals/deals_delivery_addresses_controller.rb
@@ -28,7 +28,7 @@ class Deals::DealsDeliveryAddressesController < DeliveryAddressesController
         redirect_to(new_item_purchase_path, notice: "配送先を変更しました")
       else
         flash[:alert] = '入力内容に不備があります'
-        render :new
+        render :edit
       end
     end
   end


### PR DESCRIPTION
# What
お届け先編集(updateアクション)のバリデーションエラーが発生した時のrender先がnewとなっており、
バリデーション修正後にpostをするとcreateアクションが動いてしまう不具合を修正。

# Why
正しいお届け先住所の登録をできるようにするため